### PR TITLE
Websockets - no origin check in debug mode

### DIFF
--- a/pkg/web/wsHandler.go
+++ b/pkg/web/wsHandler.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -17,13 +18,15 @@ var (
 	upgrader   = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
 	}
 )
 
 func SetupWS(newWriteWait int, newPongWait int) {
+	if os.Getenv("DEBUG") == "true" {
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			return true
+		}
+	}
 	writeWait = time.Duration(newWriteWait) * time.Second
 	pongWait = time.Duration(newPongWait) * time.Second
 	pingPeriod = (pongWait * 9) / 10

--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -4,11 +4,12 @@ if [ -z "$1" ]; then
     go get github.com/oxequa/realize
     node ui/util/cors-server.js &
     cd ui && npm start &
+    touch server.log && tail -f server.log &
     realize start
 fi
 
 if [ "$1" == "go-server" ]; then
-    ./mobile-developer-console -kubeconfig ~/.kube/config &>server.log
+    DEBUG=true ./mobile-developer-console -kubeconfig ~/.kube/config &>server.log
 fi
 
 if [ "$1" == "kill-go-server" ]; then

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1947,7 +1947,7 @@
     },
     "bootstrap": {
       "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
     "bootstrap-datepicker": {
@@ -5737,7 +5737,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {


### PR DESCRIPTION
# Motivation

In production it should check origin for websocket connections.

# Changes

- only disable origin check for debug
- print output of backend to console in debug mode