### PR TITLE
add route for user info

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -95,6 +95,9 @@ func main() {
 		web.SetupMoileClientsRoute(apiGroup, mobileClientsHandler)
 	}
 
+	userHandler := web.NewUserHandler();
+	web.SetupUserRouter(apiGroup, userHandler)
+
 	resource := "v1"
 	kind := "Secret"
 	resyncPeriod := config.OperatorResyncPeriod

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -62,3 +62,7 @@ func SetupMoileClientsRoute(r *echo.Group, handler *MobileClientsHandler) {
 	r.DELETE("/mobileclients/:name", handler.Delete)
 	r.GET("/mobileclients/watch", handler.Watch)
 }
+
+func SetupUserRouter(r *echo.Group, handler *UserHandler) {
+	r.GET("/user", handler.GetUserInfo)
+}

--- a/pkg/web/types.go
+++ b/pkg/web/types.go
@@ -102,3 +102,8 @@ type BuildConfigCreateRequest struct {
 	Build                BuildConfig     `json:"build" validate:"required"`
 	EnvironmentVariables []corev1.EnvVar `json:"envVars"`
 }
+
+type User struct {
+	Name string `json:"name"`
+	Email string `json:"email"`
+}

--- a/pkg/web/userHandler.go
+++ b/pkg/web/userHandler.go
@@ -1,0 +1,32 @@
+package web
+
+import (
+	"github.com/labstack/echo"
+	"net/http"
+)
+
+const (
+	USER_NAME_HEADER  = "X-Forwarded-User"
+	USER_EMAIL_HEADER = "X-Forwarded-Email"
+)
+
+type UserHandler struct{}
+
+func NewUserHandler() *UserHandler {
+	return &UserHandler{}
+}
+
+func (handler *UserHandler) GetUserInfo(c echo.Context) error {
+	user := &User{
+		Name:  "Unknown",
+		Email: "Unknown",
+	}
+	//these headers values will be set by the openshift oauth-proxy
+	if userNameHeader := c.Request().Header[USER_NAME_HEADER]; userNameHeader != nil && userNameHeader[0] != "" {
+		user.Name = userNameHeader[0]
+	}
+	if userEmailHeader := c.Request().Header[USER_EMAIL_HEADER]; userEmailHeader != nil && userEmailHeader[0] != "" {
+		user.Email = userEmailHeader[0]
+	}
+	return c.JSON(http.StatusOK, user)
+}

--- a/pkg/web/userHandler_test.go
+++ b/pkg/web/userHandler_test.go
@@ -1,0 +1,107 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func setupServerAndRoute(apiPrefix string) *httptest.Server {
+	h := NewUserHandler()
+
+	r := NewRouter("", apiPrefix)
+	apiRoute := r.Group(apiPrefix)
+
+	SetupUserRouter(apiRoute, h)
+	server := httptest.NewServer(r)
+	return server
+}
+
+func TestUserInfoEndpoint(t *testing.T) {
+	cases := []struct {
+		Name                   string
+		ExpectedHTTPStatusCode int
+		RequestHeaders         map[string]string
+		ExpectedUserName       string
+		ExpectedUserEmail      string
+	}{
+		{
+			Name: "Test no header values",
+			ExpectedHTTPStatusCode: 200,
+			RequestHeaders:         nil,
+			ExpectedUserName:       "Unknown",
+			ExpectedUserEmail:      "Unknown",
+		}, {
+			Name: "Test both name and email header values exist",
+			ExpectedHTTPStatusCode: 200,
+			RequestHeaders: map[string]string{
+				"X-Forwarded-User":  "testuser",
+				"X-Forwarded-Email": "testemail",
+			},
+			ExpectedUserEmail: "testemail",
+			ExpectedUserName:  "testuser",
+		}, {
+			Name: "Test only name values exist",
+			ExpectedHTTPStatusCode: 200,
+			RequestHeaders: map[string]string{
+				"X-Forwarded-User":  "testuser",
+				"X-Forwarded-Email": "",
+			},
+			ExpectedUserEmail: "Unknown",
+			ExpectedUserName:  "testuser",
+		}, {
+			Name: "Test only email values exist",
+			ExpectedHTTPStatusCode: 200,
+			RequestHeaders: map[string]string{
+				"X-Forwarded-Email": "testemail",
+				"X-Forwarded-User":  "",
+			},
+			ExpectedUserEmail: "testemail",
+			ExpectedUserName:  "Unknown",
+		},
+	}
+
+	apiPrefix = "/api"
+
+	server := setupServerAndRoute(apiPrefix)
+	defer server.Close()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			client := &http.Client{}
+			req, _ := http.NewRequest("GET", fmt.Sprintf("%s%s/user", server.URL, apiPrefix), nil)
+			if tc.RequestHeaders != nil {
+				for name, value := range tc.RequestHeaders {
+					req.Header.Set(name, value)
+				}
+			}
+			res, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Unexpected error %v", err)
+			}
+			defer res.Body.Close()
+			if res.StatusCode != tc.ExpectedHTTPStatusCode {
+				t.Fatalf("expect http status code %v, but got %v", tc.ExpectedHTTPStatusCode, res.StatusCode)
+			}
+			var user User
+			data, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				t.Fatalf("can not read http response: %v", err)
+			}
+			jerr := json.Unmarshal(data, &user)
+			if jerr != nil {
+				t.Fatalf("can not parse json data: %v", jerr)
+			}
+			if user.Name != tc.ExpectedUserName {
+				t.Fatalf("Unexpected user name: %s", user.Name)
+			}
+			if user.Email != tc.ExpectedUserEmail {
+				t.Fatalf("Unexpected user email: %s", user.Email)
+			}
+		})
+	}
+
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1947,7 +1947,7 @@
     },
     "bootstrap": {
       "version": "3.3.7",
-      "resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
     "bootstrap-datepicker": {
@@ -5737,7 +5737,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {

--- a/ui/src/DataService.js
+++ b/ui/src/DataService.js
@@ -112,10 +112,19 @@ const dataService = {
     }
   },
   fetchUser: async () => {
-    //TODO: implement me!
-    return await new Promise((resolve) => {
-      setTimeout(() => resolve({name: "John Doe"}), 1);
+    const response = await fetch(`${baseUrl}/user`, {
+      method: 'GET',
+      cache: 'no-cache',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
     });
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+    const user = await response.json();
+    return user;
   },
   logout: async () => {
     //TODO: implement me!


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-7992

## What
Show the current logged in user name in the console

## How

The openshift oauth proxy will forward the username & email info in the request headers. We just need to retrieve them and return back to the client.

## Verification Steps

1. Provision the MDC from the service catalog. Make sure the oauth proxy provisioned to protected the service.
2. Login to the service. You should see your name show up in the top right corner.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

 

