### PR TITLE
 💄use service data

### DIFF
--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -26,9 +26,9 @@ type MobileClientSpec struct {
 	// Fill me
 	ClientType    string `json:"clientType,required"`
 	Name          string `json:"name,required"`
-	AppIdentifier string `json:appIdentifier,required`
-	ApiKey        string `json:apiKey` //TODO: not sure if this is still required.
-	DmzUrl        string `json:dmzUrl`
+	AppIdentifier string `json:"appIdentifier",required`
+	ApiKey        string `json:"apiKey"` //TODO: not sure if this is still required.
+	DmzUrl        string `json:"dmzUrl"`
 }
 
 //for mobile-services.json
@@ -38,9 +38,9 @@ type MobileClientStatus struct {
 
 type MobileClientService struct {
 	Id   string `json:"id"`
-	Name string `json:name`
-	Type string `json:type`
-	Url  string `json:url`
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Url  string `json:"url"`
 	//ideally we would like to use map[string]interface{} type here, but we can't as the generated code will complain that the interface{} is not `DeepCopy`-able.
 	Config  json.RawMessage `json:"config"`
 	Version string          `json:"version"`

--- a/pkg/web/types.go
+++ b/pkg/web/types.go
@@ -23,9 +23,9 @@ type MobileAppUpdateRequest struct {
 //MobileClientServiceData represents the services in the `mobile-services.json` file
 type MobileClientServiceData struct {
 	Id     string                 `json:"id"`
-	Name   string                 `json:name`
-	Type   string                 `json:type`
-	Url    string                 `json:url`
+	Name   string                 `json:"name"`
+	Type   string                 `json:"type"`
+	Url    string                 `json:"url"`
 	Config map[string]interface{} `json:"config"`
 }
 

--- a/ui/src/components/overview/MobileClientCardView.js
+++ b/ui/src/components/overview/MobileClientCardView.js
@@ -12,8 +12,6 @@ import './MobileClientCardView.css';
 import MobileClientCardViewItem from './MobileClientCardViewItem';
 import CreateClient from '../../containers/CreateClient';
 
-const mockServices = [{ type: 'metrics' }, { type: 'keycloak' }, { type: 'sync' }, { type: 'push' }];
-
 class MobileClientCardView extends Component {
   constructor(props) {
     super(props);
@@ -96,7 +94,7 @@ class MobileClientCardView extends Component {
           <MobileClientCardViewItem
             key={clientAppName}
             app={app}
-            services={mockServices}
+            services={app.status.services}
             builds={this.getBuilds(app)}
           />
         ) : null;


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-7995

## What

Remove the mock data for services

## Why

Show the actual bound services for an app

## How

The bound services of an app are available from the `status.services` field of an app. So we just use it.

## Verification Steps

1. Get this branch running and point it to a Openshift cluster
2. Create a new app. 
3. You can try provision some mobile services and bind them to the app, but it may not work all the time. A simple way is to use oc to edit the newly created mobile app:
````
oc edit mobileclient <appname> -o json
````
then edit the json file to add new services to the status.services field. An example:

```
"services": [
             {
                 "config": {},
                 "id": "push",
                 "name": "push",
                 "type": "push",
                 "url": "http://pushserver.com",
                 "version": "1"
             },
             {
                 "config": {},
                 "id": "keycloak",
                 "name": "keycloak",
                 "type": "keycloak",
                 "url": "http://keycloak.com",
                 "version": "1"
             }
         ]
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

