### PR TITLE
Added minishift and oc-cluster-up install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can follow the docs [here](https://github.com/aerogear/mobile-core)
 Download [archive with oc client binary](https://github.com/openshift/origin/releases/tag/v3.11.0), extract it, add it to your `$PATH` and run:
 
 ```
-oc cluster up --enable=*,service-catalog,automation-service-broker,template-service-broker
+./scripts/oc-cluster-up.sh
 ```
 
 See [OpenShift documentation](https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md) for more details.
@@ -55,24 +55,10 @@ Since `oc cluster up` is causing problems for users using Mac OS (since OpenShif
 To spin up OpenShift 3.11 cluster locally, run:
 
 ```
-MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --openshift-version v3.11.0 --extra-clusterup-flags "--enable=*,service-catalog,automation-service-broker,template-service-broker"
+./scripts/minishift.sh
 ```
 
-See [Minishift](https://docs.okd.io/latest/minishift/getting-started/index.html) documentation for more details
-
-#### Cluster configuration
-
-Once your OpenShift cluster is up & running, it's required to run a post-installation configuration script:
-1. `oc login` to your cluster as user with **cluster-admin** privileges
-2. Export the name of `ansible-service-broker` project in your OpenShift instance (usually it's called `ansible-service-broker`, `openshift-ansible-service-broker` or `openshift-automation-service-broker`), i.e 
-```
-export ASB_PROJECT_NAME='openshift-automation-service-broker'
-```
-3. Run the script
-```
-./scripts/post_install.sh
-```
-4. Wait couple of minutes until Ansible Service Broker is running again
+See [Minishift](https://docs.okd.io/latest/minishift/getting-started/index.html) documentation for more details.
 
 #### Provision Mobile Services
 1. Navigate to your project in OpenShift console and search for `Mobile Developer Console` in the catalog (if it's not available, try to refresh the page and check that Ansible Service Broker is running)
@@ -84,7 +70,16 @@ export ASB_PROJECT_NAME='openshift-automation-service-broker'
 
 > :information_source: Supported version is OpenShift 3.11
 
-Follow the [steps here](#Cluster-configuration) (steps for configuration are the same for local & remote OpenShift instances).
+1. `oc login` to your cluster as user with **cluster-admin** privileges
+2. Export the name of `ansible-service-broker` project in your OpenShift instance (usually it's called `ansible-service-broker`, `openshift-ansible-service-broker` or `openshift-automation-service-broker`), i.e 
+```
+export ASB_PROJECT_NAME='openshift-automation-service-broker'
+```
+3. Run the script
+```
+./scripts/post_install.sh
+```
+4. Wait couple of minutes until Ansible Service Broker is running again
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ To spin up OpenShift 3.11 cluster locally, run:
 ./scripts/minishift.sh
 ```
 
+Once the setup is complete, it is possible to stop the cluster with `minishift stop` and then run it again with `minishift start`.
+
 See [Minishift](https://docs.okd.io/latest/minishift/getting-started/index.html) documentation for more details.
 
 #### Provision Mobile Services

--- a/scripts/minishift.sh
+++ b/scripts/minishift.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+BASEDIR="$(pwd)"
+
+minishift delete -f
+
+MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --openshift-version v3.11.0 \
+--extra-clusterup-flags "--enable=*,service-catalog,automation-service-broker,template-service-broker"
+
+oc login -u system:admin
+
+oc project default
+
+rm -rf /tmp/mini-certs
+mkdir /tmp/mini-certs
+cd /tmp/mini-certs
+
+oc get secret router-certs --template='{{index .data "tls.crt"}}' -n default  |  \
+base64 --decode | sed -e '1,/^-----END RSA PRIVATE KEY-----$/ d'  >localcluster.crt
+
+minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.crt >ca.crt
+minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.key >ca.key
+minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.serial.txt >ca.serial.txt
+
+export ROUTING_SUFFIX=$(minishift ip).nip.io
+
+oc adm ca create-server-cert \
+    --signer-cert=ca.crt \
+    --signer-key=ca.key \
+    --signer-serial=ca.serial.txt \
+    --hostnames='*.router.default.svc.cluster.local,router.default.svc.cluster.local,*.'$ROUTING_SUFFIX,$ROUTING_SUFFIX \
+    --cert=router.crt \
+    --key=router.key
+
+cat router.crt ca.crt router.key >router.pem
+
+oc get -o yaml --export secret router-certs > old-router-certs-secret.yaml
+
+oc create secret tls router-certs --cert=router.pem \
+    --key=router.key -o json --dry-run | \
+    oc replace -f -
+
+oc annotate service router \
+    service.alpha.openshift.io/serving-cert-secret-name- \
+    service.alpha.openshift.io/serving-cert-signed-by-
+
+oc annotate service router \
+    service.alpha.openshift.io/serving-cert-secret-name=router-certs
+
+oc rollout latest dc/router
+
+export ASB_PROJECT_NAME='openshift-automation-service-broker'
+
+cd "$BASEDIR"
+
+./post_install.sh
+
+echo
+echo "*******************"
+echo "Cluster certificate is located in /tmp/mini-certs/localcluster.crt. Install it to your mobile device."

--- a/scripts/minishift.sh
+++ b/scripts/minishift.sh
@@ -9,14 +9,10 @@ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --openshift-version v3.11.0 \
 
 oc login -u system:admin
 
-export ROUTING_SUFFIX=$(minishift ip).nip.io
-
-./setup-router-certs.sh
-
 export ASB_PROJECT_NAME='openshift-automation-service-broker'
 
 ./post_install.sh
 
-echo
-echo "*******************"
-echo "Cluster certificate is located in /tmp/mini-certs/localcluster.crt. Install it to your mobile device."
+export ROUTING_SUFFIX=$(minishift ip).nip.io
+
+./setup-router-certs.sh

--- a/scripts/minishift.sh
+++ b/scripts/minishift.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "$0")"
-BASEDIR="$(pwd)"
 
 minishift delete -f
 
@@ -10,49 +9,11 @@ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --openshift-version v3.11.0 \
 
 oc login -u system:admin
 
-oc project default
-
-rm -rf /tmp/mini-certs
-mkdir /tmp/mini-certs
-cd /tmp/mini-certs
-
-oc get secret router-certs --template='{{index .data "tls.crt"}}' -n default  |  \
-base64 --decode | sed -e '1,/^-----END RSA PRIVATE KEY-----$/ d'  >localcluster.crt
-
-minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.crt >ca.crt
-minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.key >ca.key
-minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.serial.txt >ca.serial.txt
-
 export ROUTING_SUFFIX=$(minishift ip).nip.io
 
-oc adm ca create-server-cert \
-    --signer-cert=ca.crt \
-    --signer-key=ca.key \
-    --signer-serial=ca.serial.txt \
-    --hostnames='*.router.default.svc.cluster.local,router.default.svc.cluster.local,*.'$ROUTING_SUFFIX,$ROUTING_SUFFIX \
-    --cert=router.crt \
-    --key=router.key
-
-cat router.crt ca.crt router.key >router.pem
-
-oc get -o yaml --export secret router-certs > old-router-certs-secret.yaml
-
-oc create secret tls router-certs --cert=router.pem \
-    --key=router.key -o json --dry-run | \
-    oc replace -f -
-
-oc annotate service router \
-    service.alpha.openshift.io/serving-cert-secret-name- \
-    service.alpha.openshift.io/serving-cert-signed-by-
-
-oc annotate service router \
-    service.alpha.openshift.io/serving-cert-secret-name=router-certs
-
-oc rollout latest dc/router
+./setup-router-certs.sh
 
 export ASB_PROJECT_NAME='openshift-automation-service-broker'
-
-cd "$BASEDIR"
 
 ./post_install.sh
 

--- a/scripts/minishift.sh
+++ b/scripts/minishift.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 minishift delete -f
 
 MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --openshift-version v3.11.0 \
---extra-clusterup-flags "--enable=*,service-catalog,automation-service-broker,template-service-broker"
+--extra-clusterup-flags "--enable=*,service-catalog,automation-service-broker,template-service-broker" || exit 1
 
 oc login -u system:admin
 

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
+oc cluster down
+
+export DEFAULT_CLUSTER_IP=$(ifconfig $(netstat -nr | awk '{if (($1 == "0.0.0.0" || $1 == "default") && $2 != "0.0.0.0" && $2 ~ /[0-9\.]+{4}/){print $NF;} }' | head -n1) | grep 'inet ' | awk '{print $2}')
+
+oc cluster up --public-hostname=$DEFAULT_CLUSTER_IP.nip.io --routing-suffix=$DEFAULT_CLUSTER_IP.nip.io \
+--enable=*,service-catalog,automation-service-broker,template-service-broker
+
+oc login -u system:admin
+
+export ROUTING_SUFFIX=$DEFAULT_CLUSTER_IP.nip.io
+
+./setup-router-certs.sh
+
+export ASB_PROJECT_NAME='openshift-automation-service-broker'
+
+./post_install.sh
+
+echo
+echo "*******************"
+echo "Cluster certificate is located in /tmp/mini-certs/localcluster.crt. Install it to your mobile device."

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -7,7 +7,7 @@ oc cluster down
 export DEFAULT_CLUSTER_IP=$(ifconfig $(netstat -nr | awk '{if (($1 == "0.0.0.0" || $1 == "default") && $2 != "0.0.0.0" && $2 ~ /[0-9\.]+{4}/){print $NF;} }' | head -n1) | grep 'inet ' | awk '{print $2}')
 
 oc cluster up --public-hostname=$DEFAULT_CLUSTER_IP.nip.io --routing-suffix=$DEFAULT_CLUSTER_IP.nip.io \
---enable=*,service-catalog,automation-service-broker,template-service-broker
+--enable=*,service-catalog,automation-service-broker,template-service-broker || exit 1
 
 oc login -u system:admin
 

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -11,14 +11,10 @@ oc cluster up --public-hostname=$DEFAULT_CLUSTER_IP.nip.io --routing-suffix=$DEF
 
 oc login -u system:admin
 
-export ROUTING_SUFFIX=$DEFAULT_CLUSTER_IP.nip.io
-
-./setup-router-certs.sh
-
 export ASB_PROJECT_NAME='openshift-automation-service-broker'
 
 ./post_install.sh
 
-echo
-echo "*******************"
-echo "Cluster certificate is located in /tmp/mini-certs/localcluster.crt. Install it to your mobile device."
+export ROUTING_SUFFIX=$DEFAULT_CLUSTER_IP.nip.io
+
+./setup-router-certs.sh

--- a/scripts/setup-router-certs.sh
+++ b/scripts/setup-router-certs.sh
@@ -1,0 +1,41 @@
+oc project default
+
+rm -rf /tmp/mini-certs
+mkdir /tmp/mini-certs
+cd /tmp/mini-certs
+
+oc get secret router-certs --template='{{index .data "tls.crt"}}' -n default  |  \
+base64 --decode | sed -e '1,/^-----END RSA PRIVATE KEY-----$/ d'  >localcluster.crt
+
+minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.crt >ca.crt
+minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.key >ca.key
+minishift ssh -- cat /var/lib/minishift/base/openshift-controller-manager/ca.serial.txt >ca.serial.txt
+
+oc adm ca create-server-cert \
+    --signer-cert=ca.crt \
+    --signer-key=ca.key \
+    --signer-serial=ca.serial.txt \
+    --hostnames='*.router.default.svc.cluster.local,router.default.svc.cluster.local,*.'$ROUTING_SUFFIX,$ROUTING_SUFFIX \
+    --cert=router.crt \
+    --key=router.key
+
+cat router.crt ca.crt router.key >router.pem
+
+oc get -o yaml --export secret router-certs > old-router-certs-secret.yaml
+
+oc create secret tls router-certs --cert=router.pem \
+    --key=router.key -o json --dry-run | \
+    oc replace -f -
+
+oc annotate service router \
+    service.alpha.openshift.io/serving-cert-secret-name- \
+    service.alpha.openshift.io/serving-cert-signed-by-
+
+oc annotate service router \
+    service.alpha.openshift.io/serving-cert-secret-name=router-certs
+
+oc rollout latest dc/router
+
+echo
+echo "*******************"
+echo "Cluster certificate is located in /tmp/mini-certs/localcluster.crt. Install it to your mobile device."


### PR DESCRIPTION
## Motivation

Currently for mac users we don't have recommendation for how to setup mobile.next with local OpenShift. The problem with minishift was with certificates installed on router by default. Because of this issue Android/iOS prevented communication with services running in OpenShift. This PR adds script that will set up minishift with correct certificates.

## Verification steps

1. `./scripts/minishift.sh`
2. deploy mdc and keycloak
3. create app and bind it with keycloak
4. verify that showcase app can communicate with keycloak