### PR TITLE
Setting default client id for binding properties

### DIFF
--- a/ui/src/components/mobileservices/MobileServiceView.js
+++ b/ui/src/components/mobileservices/MobileServiceView.js
@@ -9,6 +9,7 @@ class MobileServiceView extends Component {
     super(props);
     this.boundServiceRows = this.boundServiceRows.bind(this);
     this.unboundServiceRows = this.unboundServiceRows.bind(this);
+    this.setDefaultBindingProperties= this.setDefaultBindingProperties.bind(this);
   }
 
   componentDidMount() {
@@ -33,10 +34,21 @@ class MobileServiceView extends Component {
     if (this.props.unboundServices) {
       rows.push(<h2 key="unbound-services">Unbound Services</h2>);
       this.props.unboundServices.forEach((service) => {
+        this.setDefaultBindingProperties(service);
         rows.push(<UnboundServiceRow key={service.serviceId} service={service} />);
       });
     }
     return rows;
+  }
+
+  setDefaultBindingProperties(service) {
+    try {
+      if (service.bindingSchema.properties["CLIENT_ID"]) {
+        service.bindingSchema.properties["CLIENT_ID"].default = this.props.appName;
+      }
+    } catch {
+      console.log("Null reference setting default properties for " + service.serviceId);
+    }
   }
 
   render() {


### PR DESCRIPTION
## Motivation
During the review John asked if the client ID could be set by default.  Now it is.

## What
The default client id is set when MobileServiceView is building the unbound service row objects.

## Why
Usability.

## How
The default client id is set when MobileServiceView is building the unbound service row objects.  The function is wrapped in a try catch block that does minimal logging.  Worst case scenario is the user has to input this value themself.

## Verification Steps
When you try to bind a mobile service, you should see on the second page of the wizrd that client id is now prefilled.
 

