### PR TITLE
oc-cluster-up fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ You can follow the docs [here](https://github.com/aerogear/mobile-core)
 
 :penguin: Linux
 
+You may need to configure your firewall first:
+
+```
+sudo firewall-cmd --permanent --add-port=8443/tcp
+sudo firewall-cmd --permanent --add-port=8053/tcp
+sudo firewall-cmd --permanent --add-port=53/udp
+sudo firewall-cmd --permanent --add-port=443/tcp
+sudo firewall-cmd --permanent --add-port=80/tcp
+sudo firewall-cmd --reload
+```
+
 Download [archive with oc client binary](https://github.com/openshift/origin/releases/tag/v3.11.0), extract it, add it to your `$PATH` and run:
 
 ```

--- a/scripts/minishift.sh
+++ b/scripts/minishift.sh
@@ -14,5 +14,6 @@ export ASB_PROJECT_NAME='openshift-automation-service-broker'
 ./post_install.sh
 
 export ROUTING_SUFFIX=$(minishift ip).nip.io
+export MINISHIFT=true
 
 ./setup-router-certs.sh

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -4,17 +4,28 @@ cd "$(dirname "$0")"
 
 oc cluster down
 
-export DEFAULT_CLUSTER_IP=$(ifconfig $(netstat -nr | awk '{if (($1 == "0.0.0.0" || $1 == "default") && $2 != "0.0.0.0" && $2 ~ /[0-9\.]+{4}/){print $NF;} }' | head -n1) | grep 'inet ' | awk '{print $2}')
+if [ -z "${DEFAULT_CLUSTER_IP}" ]; then
+    export DEFAULT_CLUSTER_IP=$(ifconfig $(netstat -nr | awk '{if (($1 == "0.0.0.0" || $1 == "default") && $2 != "0.0.0.0" && $2 ~ /[0-9\.]+{4}/){print $NF;} }' | head -n1) | grep 'inet ' | awk '{print $2}')
+fi
 
-oc cluster up --public-hostname=$DEFAULT_CLUSTER_IP.nip.io --routing-suffix=$DEFAULT_CLUSTER_IP.nip.io \
---enable=*,service-catalog,automation-service-broker,template-service-broker || exit 1
+oc cluster up \
+    --public-hostname=$DEFAULT_CLUSTER_IP.nip.io \
+    --routing-suffix=$DEFAULT_CLUSTER_IP.nip.io \
+    --no-proxy=$DEFAULT_CLUSTER_IP || exit
+
+oc cluster add service-catalog
+oc cluster add automation-service-broker
+oc cluster add template-service-broker
 
 oc login -u system:admin
 
 export ASB_PROJECT_NAME='openshift-automation-service-broker'
 
+chcon -Rt svirt_sandbox_file_t .
+
 ./post_install.sh
 
 export ROUTING_SUFFIX=$DEFAULT_CLUSTER_IP.nip.io
+export CONTROLLER_MANAGER_DIR="$(pwd)/openshift.local.clusterup/openshift-controller-manager"
 
 ./setup-router-certs.sh


### PR DESCRIPTION
## Motivation

`oc-cluster-up` script was not properly tested when added. This PR should fix this script. Tested here https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/mobile-next-test/22/console

## Changes

- cluster ip can now be provided to the script (needed for ci)
- added `no-proxy` flag for `oc cluster up` (needed in ci environment)
- additional services (e.g. ansible-service-broker) installed separately from `oc cluster up` - this enables rerunning the script
- make sure temporary files are editable with `post-install` script (were blocked by se-linux)
- fix `setup-router-certs` script for oc cluster up