### PR TITLE
When delete a service binding, the view is not updated

### DIFF
--- a/ui/src/DataService.js
+++ b/ui/src/DataService.js
@@ -109,7 +109,6 @@ const dataService = {
     const boundServices = [];
 
     const instances = await fetchItems(`bindableservices/${mobileClientName}`);
-
     instances.forEach(instance => {
       if (instance.isBound) {
         boundServices.push(new BoundMobileService(instance));

--- a/ui/src/actions/serviceBinding.js
+++ b/ui/src/actions/serviceBinding.js
@@ -25,16 +25,14 @@ export const createBinding = (
   fetchAction(
     [SERVICE_BINDING_CREATE_REQUEST, SERVICE_BINDING_CREATE_SUCCESS, SERVICE_BINDING_CREATE_FAILURE],
     async () =>
-      DataService.mobileApp(formData.CLIENT_ID).then(mobileApp =>
-        DataService.createBinding(
-          mobileClientName,
-          serviceInstanceName,
-          credentialSecretName,
-          parametersSecretName,
-          serviceClassExternalName,
-          formData
-        ).then(binding => ({ mobileApp, binding, serviceInstanceName }))
-      )
+      DataService.createBinding(
+        mobileClientName,
+        serviceInstanceName,
+        credentialSecretName,
+        parametersSecretName,
+        serviceClassExternalName,
+        formData
+      ).then(binding => ({ binding, serviceInstanceName }))
   )();
 
 export const SERVICE_BINDING_DELETE_REQUEST = 'SERVICE_BINDING_DELETE_REQUEST';

--- a/ui/src/actions/serviceBinding.js
+++ b/ui/src/actions/serviceBinding.js
@@ -25,13 +25,15 @@ export const createBinding = (
   fetchAction(
     [SERVICE_BINDING_CREATE_REQUEST, SERVICE_BINDING_CREATE_SUCCESS, SERVICE_BINDING_CREATE_FAILURE],
     async () =>
-      DataService.createBinding(
-        mobileClientName,
-        serviceInstanceName,
-        credentialSecretName,
-        parametersSecretName,
-        serviceClassExternalName,
-        formData
+      DataService.mobileApp(formData.CLIENT_ID).then(mobileApp =>
+        DataService.createBinding(
+          mobileClientName,
+          serviceInstanceName,
+          credentialSecretName,
+          parametersSecretName,
+          serviceClassExternalName,
+          formData
+        ).then(binding => ({ mobileApp, binding, serviceInstanceName }))
       )
   )();
 

--- a/ui/src/components/mobileservices/MobileServiceView.js
+++ b/ui/src/components/mobileservices/MobileServiceView.js
@@ -56,16 +56,7 @@ class MobileServiceView extends Component {
 }
 
 function mapStateToProps(state) {
-  if (state.serviceBindings.items && state.serviceBindings.items.length >= 1) {
-    return {
-      boundServices: state.serviceBindings.items[0].boundServices,
-      unboundServices: state.serviceBindings.items[0].unboundServices
-    };
-  }
-  return {
-    boundServices: [],
-    unboundServices: []
-  };
+  return state.serviceBindings;
 }
 
 const mapDispatchToProps = {

--- a/ui/src/components/mobileservices/UnboundServiceRow.js
+++ b/ui/src/components/mobileservices/UnboundServiceRow.js
@@ -12,29 +12,28 @@ class UnboundServiceRow extends Component {
       showModal: false
     };
 
-    this.service = props.service;
     this.renderServiceBadge = this.renderServiceBadge.bind(this);
     this.renderBindingStatus = this.renderBindingStatus.bind(this);
   }
 
   renderServiceBadge() {
     let icon = <div />;
-    if (this.service.getIconClass() != null && this.service.getIconClass().length > 0) {
-      icon = <span className={`${this.service.getIconClass()} logo`} />;
+    if (this.props.service.getIconClass() != null && this.props.service.getIconClass().length > 0) {
+      icon = <span className={`${this.props.service.getIconClass()} logo`} />;
     } else {
-      icon = <img src={this.service.getLogoUrl()} alt="" />;
+      icon = <img src={this.props.service.getLogoUrl()} alt="" />;
     }
     return (
-      <Col md={3} key={this.service.getId()} className="service-sdk-info">
+      <Col md={3} key={this.props.service.getId()} className="service-sdk-info">
         <Col md={12}>
           {icon}
           <div className="service-name">
             <h4>
               <div>
-                <a href={`#${this.service.getId()}`}>{this.service.getName()}</a>
+                <a href={`#${this.props.service.getId()}`}>{this.props.service.getName()}</a>
               </div>
               <div>
-                <small>{this.service.getId()}</small>
+                <small>{this.props.service.getId()}</small>
               </div>
             </h4>
           </div>
@@ -46,13 +45,13 @@ class UnboundServiceRow extends Component {
   renderBindingStatus() {
     return (
       <ListView.InfoItem key="bind-status">
-        {this.service.isBindingOperationInProgress() && (
+        {this.props.service.isBindingOperationInProgress() && (
           <React.Fragment>
             <Icon name="spinner" spin size="lg" />
-            {this.service.getBindingOperation()} In Progress
+            {this.props.service.getBindingOperation()} In Progress
           </React.Fragment>
         )}
-        {this.service.isBindingOperationFailed() && (
+        {this.props.service.isBindingOperationFailed() && (
           <React.Fragment>
             <Icon type="pf" name="error-circle-o" />
             Operation Failed. Please Try Again Later.
@@ -63,7 +62,7 @@ class UnboundServiceRow extends Component {
   }
 
   renderBindingButtons() {
-    if (this.service.isBindingOperationInProgress()) {
+    if (this.props.service.isBindingOperationInProgress()) {
       return null;
     }
     return (
@@ -81,7 +80,7 @@ class UnboundServiceRow extends Component {
           actions={this.renderBindingButtons()}
         />
         <BindingPanel
-          service={this.service}
+          service={this.props.service}
           showModal={this.state.showModal}
           close={() => {
             this.setState({ showModal: false });

--- a/ui/src/containers/DeleteItemButton.js
+++ b/ui/src/containers/DeleteItemButton.js
@@ -33,6 +33,7 @@ class DeleteItemButton extends Component {
     // See https://github.com/react-bootstrap/react-bootstrap/issues/541
     document.dispatchEvent(new MouseEvent('click'));
     navigate && history.replace(navigate);
+    this.handleDialogClose();
   };
 
   openDialog = () => {

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -70,6 +70,18 @@ export class BoundMobileService extends MobileService {
   getDocumentationUrl() {
     return this.serviceClass.spec.get('externalMetadata.documentationUrl');
   }
+
+  /**
+   * This method returns an instance of 'UnboundMobileService' with a state of 'Unbinding in progress'
+   * @returns {UnboundMobileService}
+   */
+  unbind() {
+    return new UnboundMobileService({
+      ...this.data,
+      isBound: false,
+      serviceBinding: { status: { currentOperation: 'Unbinding', conditions: [{ type: 'Ready', status: 'False' }] } }
+    });
+  }
 }
 
 export class UnboundMobileService extends MobileService {
@@ -116,6 +128,18 @@ export class UnboundMobileService extends MobileService {
       return true;
     }
     return false;
+  }
+
+  /**
+   * This method returns a new instance of UnboundMobileService, with a status of 'Binding in progress'
+   * @returns {UnboundMobileService}
+   */
+  bind() {
+    return new UnboundMobileService({
+      ...this.data,
+      isBound: false,
+      serviceBinding: { status: { currentOperation: 'Binding', conditions: [{ type: 'Ready', status: 'False' }] } }
+    });
   }
 
   toJSON() {

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -4,7 +4,7 @@ import Resource from '../k8s/resource';
 export class MobileService {
   constructor(json = {}) {
     this.data = json;
-    this.configuration = this.data.configuration || {};
+    this.configuration = this.data.configuration || [];
     this.setupText = '';
     this.serviceInstance = new Resource(this.data.serviceInstance);
     this.serviceBinding = new Resource(this.data.serviceBinding);

--- a/ui/src/reducers/serviceBindings.js
+++ b/ui/src/reducers/serviceBindings.js
@@ -65,7 +65,7 @@ const serviceBindingsReducer = (state = defaultState, action) => {
       return {
         ...state,
         isCreating: false,
-        errors: getErrors(null, 'create', state.errors),
+        errors: getErrors(null, 'create', state.errors)
       };
     case SERVICE_BINDING_CREATE_FAILURE:
       return {

--- a/ui/src/reducers/serviceBindings.js
+++ b/ui/src/reducers/serviceBindings.js
@@ -97,10 +97,7 @@ const serviceBindingsReducer = (state = defaultState, action) => {
       };
     case SERVICE_BINDING_DELETE_SUCCESS: {
       const deletedBindingName = action.result;
-      const index = findIndex(
-        state.boundServices,
-        item => item.serviceBinding.metadata.data.name === deletedBindingName
-      );
+      const index = findIndex(state.boundServices, item => item.getBindingName() === deletedBindingName);
       return {
         ...state,
         isDeleting: false,

--- a/ui/src/reducers/serviceBindings.js
+++ b/ui/src/reducers/serviceBindings.js
@@ -12,7 +12,8 @@ import {
 
 const defaultState = {
   isFetching: false,
-  items: [],
+  boundServices: [],
+  unboundServices: [],
   errors: [],
   isCreating: false,
   isDeleting: false,
@@ -35,7 +36,6 @@ const getErrors = (error, type, errors) => {
 };
 
 const serviceBindingsReducer = (state = defaultState, action) => {
-  let index;
   switch (action.type) {
     case SERVICE_BINDINGS_REQUEST:
       return {
@@ -43,20 +43,12 @@ const serviceBindingsReducer = (state = defaultState, action) => {
         isReading: true
       };
     case SERVICE_BINDINGS_SUCCESS:
-      index = state.items.findIndex(item => item.metadata.name === action.result.metadata.name);
-      if (index >= 0) {
-        return {
-          ...state,
-          isReading: false,
-          items: [...state.items.slice(0, index), action.result, ...state.items.slice(index + 1)],
-          errors: getErrors(null, 'read', state.errors)
-        };
-      }
       return {
         ...state,
         isReading: false,
-        items: [...state.items, action.result],
-        errors: getErrors(null, 'read', state.errors)
+        errors: getErrors(null, 'read', state.errors),
+        boundServices: action.result.boundServices,
+        unboundServices: action.result.unboundServices
       };
     case SERVICE_BINDINGS_FAILURE:
       return {
@@ -74,7 +66,6 @@ const serviceBindingsReducer = (state = defaultState, action) => {
         ...state,
         isCreating: false,
         errors: getErrors(null, 'create', state.errors),
-        items: [...state.items, action.result]
       };
     case SERVICE_BINDING_CREATE_FAILURE:
       return {

--- a/ui/src/reducers/serviceBindings.test.js
+++ b/ui/src/reducers/serviceBindings.test.js
@@ -1,0 +1,190 @@
+import {
+  SERVICE_BINDINGS_REQUEST,
+  SERVICE_BINDINGS_SUCCESS,
+  SERVICE_BINDINGS_FAILURE,
+  SERVICE_BINDING_CREATE_REQUEST,
+  SERVICE_BINDING_CREATE_SUCCESS,
+  SERVICE_BINDING_CREATE_FAILURE,
+  SERVICE_BINDING_DELETE_REQUEST,
+  SERVICE_BINDING_DELETE_SUCCESS,
+  SERVICE_BINDING_DELETE_FAILURE
+} from '../actions/serviceBinding';
+import serviceBindingReducer from './serviceBindings';
+import { BoundMobileService, UnboundMobileService } from '../models';
+
+const defaultState = {
+  isFetching: false,
+  boundServices: [],
+  unboundServices: [],
+  errors: [],
+  isCreating: false,
+  isDeleting: false,
+  isActioning: false,
+  isReading: false
+};
+
+function getInitialState() {
+  // ensure deep copy
+  return JSON.parse(JSON.stringify(defaultState));
+}
+
+function randomInt(low, high) {
+  return Math.floor(Math.random() * (high - low) + low);
+}
+
+function createTestBoundService(serviceInstanceName, bindingName) {
+  const json = {
+    data: {
+      name: `test${randomInt(0, 10000)}`
+    },
+    serviceInstance: {
+      metadata: {
+        name: serviceInstanceName
+      }
+    },
+    serviceBinding: {
+      metadata: {
+        name: bindingName
+      }
+    }
+  };
+  return new BoundMobileService(json);
+}
+
+function createTestUnboundService(serviceInstanceName) {
+  const json = {
+    data: {
+      name: `test${randomInt(0, 10000)}`
+    },
+    serviceInstance: {
+      metadata: {
+        name: serviceInstanceName
+      }
+    }
+  };
+  return new UnboundMobileService(json);
+}
+
+describe('Fetch Bindings', () => {
+  it('test service bindings request', () => {
+    const initialState = { ...getInitialState() };
+    const newState = serviceBindingReducer(initialState, { type: SERVICE_BINDINGS_REQUEST });
+    expect(newState).toEqual({ ...initialState, isReading: true });
+    expect(initialState).toEqual(defaultState);
+  });
+
+  it('test service bindings success', () => {
+    const initialState = { ...getInitialState() };
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDINGS_SUCCESS,
+      result: {
+        boundServices: [
+          createTestBoundService('test-instance', 'test-binding1'),
+          createTestBoundService('test-instance1', 'test-binding2')
+        ],
+        unboundServices: [createTestUnboundService('test-instance2')]
+      }
+    });
+    expect(newState.isReading).toBe(false);
+    expect(newState.boundServices).toHaveLength(2);
+    expect(newState.unboundServices).toHaveLength(1);
+  });
+
+  it('test service bindings failure', () => {
+    const initialState = { ...getInitialState() };
+
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDINGS_FAILURE,
+      error: 'service binding test fetching error'
+    });
+    expect(newState.isReading).toBe(false);
+    expect(newState.errors).toHaveLength(1);
+    expect(newState.errors[0]).toEqual({ error: 'service binding test fetching error', type: 'read' });
+  });
+});
+
+describe('Create Binding', () => {
+  it('test create request', () => {
+    const initialState = { ...getInitialState() };
+    const newState = serviceBindingReducer(initialState, { type: SERVICE_BINDING_CREATE_REQUEST });
+    expect(newState).toEqual({ ...initialState, isCreating: true });
+    expect(initialState).toEqual(defaultState);
+  });
+
+  it('test create success', () => {
+    const initialState = {
+      ...getInitialState(),
+      unboundServices: [createTestUnboundService('test-instance')]
+    };
+
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDING_CREATE_SUCCESS,
+      result: { serviceInstanceName: 'test-instance' }
+    });
+    expect(newState.isCreating).toBe(false);
+    expect(newState.unboundServices).toHaveLength(1);
+    expect(newState.boundServices).toHaveLength(0);
+    const unboundService = newState.unboundServices[0];
+    expect(unboundService.isBindingOperationInProgress()).toBe(true);
+    expect(unboundService.getBindingOperation()).toBe('Binding');
+  });
+
+  it('test create failure', () => {
+    const initialState = {
+      ...getInitialState(),
+      unboundServices: [createTestUnboundService('test-instance')]
+    };
+
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDING_CREATE_FAILURE,
+      error: 'service binding test error'
+    });
+    expect(newState.isCreating).toBe(false);
+    expect(newState.unboundServices).toHaveLength(1);
+    expect(newState.errors).toHaveLength(1);
+    expect(newState.errors[0]).toEqual({ error: 'service binding test error', type: 'create' });
+  });
+});
+
+describe('Delete Binding', () => {
+  it('test delete request', () => {
+    const initialState = { ...getInitialState() };
+    const newState = serviceBindingReducer(initialState, { type: SERVICE_BINDING_DELETE_REQUEST });
+    expect(newState).toEqual({ ...initialState, isDeleting: true });
+    expect(initialState).toEqual(defaultState);
+  });
+
+  it('test delete success', () => {
+    const initialState = {
+      ...getInitialState(),
+      boundServices: [createTestBoundService('test-instance', 'test-binding1')]
+    };
+
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDING_DELETE_SUCCESS,
+      result: 'test-binding1'
+    });
+    expect(newState.isDeleting).toBe(false);
+    expect(newState.boundServices).toHaveLength(0);
+    expect(newState.unboundServices).toHaveLength(1);
+    const unboundService = newState.unboundServices[0];
+    expect(unboundService.isBindingOperationInProgress()).toBe(true);
+    expect(unboundService.getBindingOperation()).toBe('Unbinding');
+  });
+
+  it('test delete failure', () => {
+    const initialState = {
+      ...getInitialState(),
+      unboundServices: [createTestUnboundService('test-instance')]
+    };
+
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDING_DELETE_FAILURE,
+      error: 'service unbinding test error'
+    });
+    expect(newState.isDeleting).toBe(false);
+    expect(newState.unboundServices).toHaveLength(1);
+    expect(newState.errors.length).toBe(1);
+    expect(newState.errors[0]).toEqual({ error: 'service unbinding test error', type: 'delete' });
+  });
+});


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8128

## Progress

- [x] Move service bindings reducers to its own module
- [x] Change the reducer to put only binding data into the binding data store

## Verification Steps

### Binding
1. Click on an existing application to see its details
2. Click on mobile services
3. Bind a new service
5. Verify the the dialog closes and the service is put in 'Binding in progress'

### Unbinding
1. Click on an existing application to see its details
2. Click on mobile services
3. If the application has no services bound, bind a new one
4. Delete one bound service
5. Verify the the dialog closes and the service is put in 'Unbinding in progress'

**NOTE:** Currently the service will remain to the `in progress` state until you refresh. @secondsun is working on a Websocket implementation that should receive events from the server