### PR TITLE
Installer fix - waiting for asb deployment

### DIFF
--- a/scripts/minishift.sh
+++ b/scripts/minishift.sh
@@ -9,8 +9,6 @@ MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --openshift-version v3.11.0 \
 
 oc login -u system:admin
 
-export ASB_PROJECT_NAME='openshift-automation-service-broker'
-
 ./post_install.sh
 
 export ROUTING_SUFFIX=$(minishift ip).nip.io

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -11,15 +11,13 @@ fi
 oc cluster up \
     --public-hostname=$DEFAULT_CLUSTER_IP.nip.io \
     --routing-suffix=$DEFAULT_CLUSTER_IP.nip.io \
-    --no-proxy=$DEFAULT_CLUSTER_IP || exit
+    --no-proxy=$DEFAULT_CLUSTER_IP || exit 1
 
 oc cluster add service-catalog
 oc cluster add automation-service-broker
 oc cluster add template-service-broker
 
 oc login -u system:admin
-
-export ASB_PROJECT_NAME='openshift-automation-service-broker'
 
 chcon -Rt svirt_sandbox_file_t .
 

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "$0")" || exit 1
+ASB_PROJECT_NAME=$(oc get projects | grep -e ansible-service-broker -e automation-service-broker | awk '{print $1}')
 if [ -z "$ASB_PROJECT_NAME" ]
 then
-    echo "Please specify OpenShift ASB project before running this script. E.g.:"
-    echo "export ASB_PROJECT_NAME='openshift-automation-service-broker'"
+    echo "Ansible service broker project not found."
     exit 1
 fi
 oc project "$ASB_PROJECT_NAME" || exit 1
@@ -16,7 +16,6 @@ UPDATE_INSTRUCTIONS="yml/update_instructions.yaml"
 AEROGEARCATALOG_REGISTRY="yml/aerogearcatalog_registry.yaml"
 ASB_TEMPLATE_FILENAME="_tmp-asb-template.yaml"
 ASB_DC_NAME=$(oc get dc -o jsonpath='{.items[*].metadata.name}' -n "$ASB_PROJECT_NAME")
-ASB_CONTAINER_COUNT=$(oc get pods -l app="$ASB_PROJECT_NAME" -o jsonpath='{.items[*].spec.containers[*].name}' -n "$ASB_PROJECT_NAME" | wc -w | awk '{$1=$1};1')
 
 # Mobile CRD (mobileclient)
 oc create -f ../deploy/crd.yaml
@@ -24,16 +23,18 @@ oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,upd
 oc adm policy add-cluster-role-to-group mobileclient-admin system:authenticated
 
 # ASB configuration
-until oc get pods -l app="$ASB_PROJECT_NAME" -n "$ASB_PROJECT_NAME" | grep "$ASB_CONTAINER_COUNT/$ASB_CONTAINER_COUNT"
-do
-    echo "Waiting for ASB to spin up" && sleep 5
-done
 oc get configmap broker-config -n "$ASB_PROJECT_NAME" -o jsonpath='{.data.broker-config}' > $ASB_TEMPLATE_FILENAME
-# Append dockerhub registry target - aerogearcatalog
-$yq m -a -i $ASB_TEMPLATE_FILENAME $AEROGEARCATALOG_REGISTRY
-# Additional changes to broker configuration file
-$yq w -i -s $UPDATE_INSTRUCTIONS $ASB_TEMPLATE_FILENAME
-# Replace double quotes with single quotes
-sed -i.bak -e "s/\"/'/g" $ASB_TEMPLATE_FILENAME
-oc patch configmap broker-config -p "{\"data\":{\"broker-config\": \"$(awk '{printf "%s\\n", $0}' ${ASB_TEMPLATE_FILENAME})\"}}" -n "$ASB_PROJECT_NAME"
-oc rollout latest "$ASB_DC_NAME" -n "$ASB_PROJECT_NAME"
+if ! $yq r $ASB_TEMPLATE_FILENAME registry.*.org | grep aerogearcatalog &>/dev/null ; then
+    while oc rollout history dc/"$ASB_DC_NAME" -n "$ASB_PROJECT_NAME" | grep Running &>/dev/null
+    do
+        echo "Waiting for ASB to spin up" && sleep 5
+    done
+    # Append dockerhub registry target - aerogearcatalog
+    $yq m -a -i $ASB_TEMPLATE_FILENAME $AEROGEARCATALOG_REGISTRY
+    # Additional changes to broker configuration file
+    $yq w -i -s $UPDATE_INSTRUCTIONS $ASB_TEMPLATE_FILENAME
+    # Replace double quotes with single quotes
+    sed -i.bak -e "s/\"/'/g" $ASB_TEMPLATE_FILENAME
+    oc patch configmap broker-config -p "{\"data\":{\"broker-config\": \"$(awk '{printf "%s\\n", $0}' ${ASB_TEMPLATE_FILENAME})\"}}" -n "$ASB_PROJECT_NAME"
+    oc rollout latest "$ASB_DC_NAME" -n "$ASB_PROJECT_NAME"
+fi

--- a/scripts/setup-router-certs.sh
+++ b/scripts/setup-router-certs.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 oc project default
 
 rm -rf /tmp/oc-certs


### PR DESCRIPTION
## Motivation

https://trello.com/c/zQBCWwKI/25-1-replace-waiting-for-asb-to-spin-up-with-canceling-deployment-in-installer

- canceling of deployment is not supported in oc 3.11
- current implementation checks number of running pods which does not work properly every time
- replaced with deployment status check

https://trello.com/c/Dbyr6z40/42-1-get-name-of-asb-project-in-installer-automatically

Also added condition that checks if ASB was already configured, if so the config is skipped.
