### PR TITLE
 🐛 remember the selected tab on the app details view

### DIFF
--- a/ui/src/containers/Client.js
+++ b/ui/src/containers/Client.js
@@ -13,6 +13,7 @@ import {
 } from 'patternfly-react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { find } from 'lodash-es';
 import ConfigurationView from '../components/configuration/ConfigurationView';
 import MobileServiceView from '../components/mobileservices/MobileServiceView';
 import { fetchApp } from '../actions/apps';
@@ -26,17 +27,23 @@ import './Client.css';
 import { MobileClientBuildOverviewList } from '../components/build/MobileClientBuildOverviewList';
 import BuildConfigDialog from './BuildConfigDialog';
 
-const TAB_CONFIGURATION = 1;
-const TAB_MOBILE_SERVICES = 2;
-const TAB_BUILDS = 3;
+export const TAB_CONFIGURATION = { key: 1, hash: 'configuration' };
+export const TAB_MOBILE_SERVICES = { key: 2, hash: 'services' };
+export const TAB_BUILDS = { key: 3, hash: 'builds' };
 
-class Client extends Component {
+const TABS = [TAB_CONFIGURATION, TAB_MOBILE_SERVICES, TAB_BUILDS];
+
+export class Client extends Component {
   constructor(props) {
     super(props);
+    let initialTab = find(TABS, { hash: props.location.hash.substring(1) });
+    if (!initialTab) {
+      initialTab = TAB_CONFIGURATION;
+    }
 
     this.state = {
       buildConfigs: [],
-      selectedTab: TAB_CONFIGURATION
+      selectedTab: initialTab.key
     };
     this.handleNavSelect = this.handleNavSelect.bind(this);
   }
@@ -107,7 +114,7 @@ class Client extends Component {
         </div>
         <div className="app-actions-dropdown">
           <DropdownButton id="app-actions-dropdown" title="Actions" pullRight>
-            {mobileApp && selectedTab === TAB_BUILDS ? (
+            {mobileApp && selectedTab === TAB_BUILDS.key ? (
               <React.Fragment>
                 <MenuItem onClick={() => this.setState({ showBuildConfigDialog: true })}>New build config</MenuItem>
                 <BuildConfigDialog
@@ -147,19 +154,27 @@ class Client extends Component {
           <TabContainer id="basic-tabs-pf" activeKey={selectedTab} onSelect={this.handleNavSelect}>
             <div>
               <Nav bsClass="nav nav-tabs nav-tabs-pf nav-tabs-pf-secondary">
-                <NavItem eventKey={TAB_CONFIGURATION}>Configuration</NavItem>
-                {this.props.buildTabEnabled ? <NavItem eventKey={TAB_BUILDS}>Builds</NavItem> : null}
-                <NavItem eventKey={TAB_MOBILE_SERVICES}>Mobile Services</NavItem>
+                <NavItem eventKey={TAB_CONFIGURATION.key} href={`#${TAB_CONFIGURATION.hash}`}>
+                  Configuration
+                </NavItem>
+                {this.props.buildTabEnabled ? (
+                  <NavItem eventKey={TAB_BUILDS.key} href={`#${TAB_BUILDS.hash}`}>
+                    Builds
+                  </NavItem>
+                ) : null}
+                <NavItem eventKey={TAB_MOBILE_SERVICES.key} href={`#${TAB_MOBILE_SERVICES.hash}`}>
+                  Mobile Services
+                </NavItem>
               </Nav>
               <TabContent>
-                <TabPane eventKey={TAB_CONFIGURATION}>
+                <TabPane eventKey={TAB_CONFIGURATION.key}>
                   <ConfigurationView app={mobileApp} />
                 </TabPane>
-                <TabPane eventKey={TAB_MOBILE_SERVICES}>
+                <TabPane eventKey={TAB_MOBILE_SERVICES.key}>
                   <MobileServiceView appName={appName} />
                 </TabPane>
                 {this.props.buildTabEnabled ? (
-                  <TabPane eventKey={TAB_BUILDS}>
+                  <TabPane eventKey={TAB_BUILDS.key}>
                     <MobileClientBuildOverviewList
                       appName={appName}
                       clientInfo={clientInfo}

--- a/ui/src/containers/Client.test.js
+++ b/ui/src/containers/Client.test.js
@@ -1,0 +1,82 @@
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import { TabContainer, NavItem } from 'patternfly-react';
+import { Client, TAB_CONFIGURATION, TAB_MOBILE_SERVICES } from './Client';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('../DataService');
+
+describe('Client', () => {
+  it('test render all tabs', () => {
+    const mockFetchApp = jest.fn();
+    const mockFetchBuilds = jest.fn();
+    const mockFetchBuildConfigs = jest.fn();
+
+    const props = {
+      location: { hash: '' },
+      match: { params: { id: 'testapp' } },
+      fetchApp: mockFetchApp,
+      buildTabEnabled: true,
+      fetchBuildConfigs: mockFetchBuildConfigs,
+      fetchBuilds: mockFetchBuilds,
+      apps: { items: [{ metadata: { name: 'testapp' }, spec: { name: 'testapp' } }] },
+      buildConfigs: { items: [] }
+    };
+
+    const wrapper = shallow(<Client {...props} />);
+    expect(mockFetchApp).toBeCalled();
+    expect(mockFetchBuilds).toBeCalled();
+    expect(mockFetchBuildConfigs).toBeCalled();
+    expect(wrapper.find(TabContainer).prop('activeKey')).toEqual(TAB_CONFIGURATION.key);
+    expect(wrapper.find(NavItem)).toHaveLength(3);
+  });
+
+  it('test not render build tab', () => {
+    const mockFetchApp = jest.fn();
+    const mockFetchBuilds = jest.fn();
+    const mockFetchBuildConfigs = jest.fn();
+
+    const props = {
+      location: { hash: '' },
+      match: { params: { id: 'testapp' } },
+      fetchApp: mockFetchApp,
+      buildTabEnabled: false,
+      fetchBuildConfigs: mockFetchBuildConfigs,
+      fetchBuilds: mockFetchBuilds,
+      apps: { items: [{ metadata: { name: 'testapp' }, spec: { name: 'testapp' } }] },
+      buildConfigs: { items: [] }
+    };
+
+    const wrapper = shallow(<Client {...props} />);
+    expect(mockFetchApp).toBeCalled();
+    expect(mockFetchBuilds).not.toBeCalled();
+    expect(mockFetchBuildConfigs).not.toBeCalled();
+    expect(wrapper.find(NavItem)).toHaveLength(2);
+  });
+
+  it('test render service tab by default', () => {
+    const mockFetchApp = jest.fn();
+    const mockFetchBuilds = jest.fn();
+    const mockFetchBuildConfigs = jest.fn();
+
+    const props = {
+      location: { hash: `#${TAB_MOBILE_SERVICES.hash}` },
+      match: { params: { id: 'testapp' } },
+      fetchApp: mockFetchApp,
+      buildTabEnabled: true,
+      fetchBuildConfigs: mockFetchBuildConfigs,
+      fetchBuilds: mockFetchBuilds,
+      apps: { items: [{ metadata: { name: 'testapp' }, spec: { name: 'testapp' } }] },
+      buildConfigs: { items: [] }
+    };
+
+    const wrapper = shallow(<Client {...props} />);
+    expect(mockFetchApp).toBeCalled();
+    expect(mockFetchBuilds).toBeCalled();
+    expect(mockFetchBuildConfigs).toBeCalled();
+    expect(wrapper.find(TabContainer).prop('activeKey')).toEqual(TAB_MOBILE_SERVICES.key);
+    expect(wrapper.find(NavItem)).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8127

## What

When the app details page is refreshed, the `configuration` tab is always shown by default


## How

To fix it, update the url with hash value of the page, so that the selected tab will be part of the url

## Verification Steps

1. Go to the details view of an app, you should see the configuration page by default.
2. Select the `Builds` or `Mobile Services` tab
3. Refresh the page, you should stay on that page.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

