### PR TITLE
Removed clusterName from mobile-services.json

### DIFF
--- a/pkg/web/mobileClientsHandler.go
+++ b/pkg/web/mobileClientsHandler.go
@@ -37,9 +37,9 @@ func newMobileClientObject(data MobileAppCreateRequest, namespace string) *v1alp
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.MobileClientSpec{
-			Name:          data.Name,
-			ApiKey:        uuid.NewV4().String(),
-			DmzUrl:        data.DmzUrl,
+			Name:   data.Name,
+			ApiKey: uuid.NewV4().String(),
+			DmzUrl: data.DmzUrl,
 		},
 	}
 }
@@ -70,11 +70,10 @@ func newMoileClientDataFromObject(app *v1alpha1.MobileClient, openshiftMasterURL
 		services = append(services, *s)
 	}
 	status := &MobileClientStatusData{
-		Version:     1,
-		ClusterName: openshiftMasterURL,
-		Namespace:   app.GetNamespace(),
-		ClientId:    app.Spec.Name,
-		Services:    services,
+		Version:   1,
+		Namespace: app.GetNamespace(),
+		ClientId:  app.Spec.Name,
+		Services:  services,
 	}
 	return &MobileClientData{
 		TypeMeta:   app.TypeMeta,

--- a/pkg/web/types.go
+++ b/pkg/web/types.go
@@ -9,8 +9,8 @@ import (
 //MobileAppCreateRequest is the data type for the create request
 type MobileAppCreateRequest struct {
 	//has to be unique per namespace, can not be changed later
-	Name          string `json:"name" validate:"required"`
-	DmzUrl        string `json:"dmzUrl"`
+	Name   string `json:"name" validate:"required"`
+	DmzUrl string `json:"dmzUrl"`
 }
 
 //MobileAppUpdateRequest is the data type for the update request
@@ -37,11 +37,10 @@ type MobileClientData struct {
 
 //MobileClientStatusData represents the content in the `mobile-services.json` file
 type MobileClientStatusData struct {
-	Version     int                       `json:"version"`
-	ClusterName string                    `json:"clusterName"`
-	Namespace   string                    `json:"namespace"`
-	ClientId    string                    `json:"clientId"`
-	Services    []MobileClientServiceData `json:"services"`
+	Version   int                       `json:"version"`
+	Namespace string                    `json:"namespace"`
+	ClientId  string                    `json:"clientId"`
+	Services  []MobileClientServiceData `json:"services"`
 }
 
 //MobileClientDataList is the list of MobileClientServiceData

--- a/ui/src/models/mobileapps/mobileappstatus.js
+++ b/ui/src/models/mobileapps/mobileappstatus.js
@@ -13,10 +13,6 @@ export default class AppStatus extends Status {
     return this.get('clientId');
   }
 
-  getClusterName() {
-    return this.get('clusterName');
-  }
-
   getNamespace() {
     return this.get('namespace');
   }

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -96,7 +96,7 @@ export class UnboundMobileService extends MobileService {
 
   setBindingSchemaDefaultValues(name, value) {
     const bindingSchema = this.getBindingSchema();
-    if (bindingSchema && bindingSchema.properties[name]) {
+    if (bindingSchema && bindingSchema.properties && bindingSchema.properties[name]) {
       bindingSchema.properties[name].default = value;
     }
   }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8131

## What

- Removed clusterName from mobile-services.json
- fixed bug where web-app crashes when there is MDC provisioned in currently used project.


