### PR TITLE
[SPIKE] Filter display group by

### DIFF
--- a/ui/src/components/mobileservices/bindingPanelUtils.js
+++ b/ui/src/components/mobileservices/bindingPanelUtils.js
@@ -6,6 +6,7 @@ export const OpenShiftObjectTemplate = function({
   uiSchema,
   schema,
   properties,
+  formData,
   idSchema,
   title,
   description
@@ -14,13 +15,15 @@ export const OpenShiftObjectTemplate = function({
   return (
     <div>
       <TitleField title={title} />
-      <div className="row">{form.map(key => getOpenShiftField(key, properties, idSchema, schema))}</div>
+      <div className="row">
+        {form.map(key => getOpenShiftField(key, properties, idSchema, schema, formData, uiSchema))}
+      </div>
       {description}
     </div>
   );
 };
 
-function getOpenShiftField(field, properties, idSchema, schema) {
+function getOpenShiftField(field, properties, idSchema, schema, formData, uiSchema) {
   if (!field.items) {
     const property = properties.find(prop => prop.name === field);
     const id = idSchema[field].$id;
@@ -69,10 +72,10 @@ function getOpenShiftField(field, properties, idSchema, schema) {
     }
     return <div key={property.content.key}>{property.content}</div>;
   }
-  return getFieldSet(field, properties, idSchema, schema);
+  return getFieldSet(field, properties, idSchema, schema, formData, uiSchema);
 }
 
-function getFieldSet(field, properties, idSchema, schema) {
+function getFieldSet(field, properties, idSchema, schema, formData, uiSchema) {
   const { title, items } = field;
 
   const fieldSetItems = items.map(item => {
@@ -123,7 +126,17 @@ function getFieldSet(field, properties, idSchema, schema) {
         return property.content;
     }
   });
-
+  if (uiSchema.form.filterDisplayGroupBy) {
+    if (field.title.toLowerCase().localeCompare(formData[uiSchema.form.filterDisplayGroupBy].toLowerCase()) === 0) {
+      return (
+        <fieldset key={field.title}>
+          <h2>{title}</h2>
+          {fieldSetItems}
+        </fieldset>
+      );
+    }
+    return <div />;
+  }
   return (
     <fieldset key={field.title}>
       <h2>{title}</h2>

--- a/ui/src/components/mobileservices/bindingPanelUtils.js
+++ b/ui/src/components/mobileservices/bindingPanelUtils.js
@@ -52,7 +52,7 @@ function getOpenShiftField(field, properties, idSchema, schema) {
           <select
             className="form-control"
             multiple={false}
-            defaultValue={typeof defaultValue === "undefined" ? "" : defaultValue}
+            defaultValue={typeof defaultValue === 'undefined' ? '' : defaultValue}
             id={id}
             onChange={event => {
               property.content.props.onChange(event.target.value);
@@ -67,7 +67,6 @@ function getOpenShiftField(field, properties, idSchema, schema) {
         </div>
       );
     }
-    console.log(field)
     return <div key={property.content.key}>{property.content}</div>;
   }
   return getFieldSet(field, properties, idSchema, schema);

--- a/ui/src/components/mobileservices/bindingPanelUtils.js
+++ b/ui/src/components/mobileservices/bindingPanelUtils.js
@@ -43,7 +43,7 @@ function getOpenShiftField(field, properties, idSchema, schema) {
       );
     } else if (field === 'CLIENT_TYPE') {
       const enumArray = schema.properties[field].enum;
-
+      const defaultValue = schema.properties[field].default;
       return (
         <div key={property.content.key}>
           <label className="control-label" htmlFor={id}>
@@ -52,6 +52,7 @@ function getOpenShiftField(field, properties, idSchema, schema) {
           <select
             className="form-control"
             multiple={false}
+            defaultValue={typeof defaultValue === "undefined" ? "" : defaultValue}
             id={id}
             onChange={event => {
               property.content.props.onChange(event.target.value);
@@ -66,6 +67,7 @@ function getOpenShiftField(field, properties, idSchema, schema) {
         </div>
       );
     }
+    console.log(field)
     return <div key={property.content.key}>{property.content}</div>;
   }
   return getFieldSet(field, properties, idSchema, schema);

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -102,7 +102,11 @@ export class UnboundMobileService extends MobileService {
   }
 
   getFormDefinition() {
-    return this.servicePlan.spec.get('externalMetadata.schemas.service_binding.create.openshift_form_definition');
+    const form = this.servicePlan.spec.get('externalMetadata.schemas.service_binding.create.openshift_form_definition');
+    form.filterDisplayGroupBy = JSON.parse(
+      this.servicePlan.spec.get('externalMetadata.mobileclient_bind_parameters_data[0]') || ''
+    ).filterDisplayGroupBy;
+    return form;
   }
 
   getServiceClassExternalName() {

--- a/ui/src/reducers/serviceBindings.test.js
+++ b/ui/src/reducers/serviceBindings.test.js
@@ -184,7 +184,7 @@ describe('Delete Binding', () => {
     });
     expect(newState.isDeleting).toBe(false);
     expect(newState.unboundServices).toHaveLength(1);
-    expect(newState.errors.length).toBe(1);
+    expect(newState.errors).toHaveLength(1);
     expect(newState.errors[0]).toEqual({ error: 'service unbinding test error', type: 'delete' });
   });
 });


### PR DESCRIPTION
@wei-lee @ziccardi , Wei and I were discussing what you and I were discussing Massimo and I wanted to try to find a more generic way to do the filtering and I think I found it.

This PR works in conjuction with editing the cluster service plan for the UPS APB to add a "filterDisplayGroupBy":"CLIENT_TYPE" field to the mobileclient_bind_parameters_data if the apb.  (SEE https://github.com/aerogearcatalog/unifiedpush-apb/blob/master/apb.yml#L32 where it would go).

Anyway, I know last we spoke MZ I was against this.  Wei convinced me that I was still against this, but we needed it ;)  Here is my attempt to implement this without adding a lot of custom code.

If we adopt this PR we will need to update the apb.  You can update your own clusterserviceplan using `oc edit clusterserviceplan` as a cluster admin (ie system:admin)

## Demo
https://youtu.be/zByRFTe7FTI