### PR TITLE
AEROGEAR-8137

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[ui/*]
+indent_style = space
+
+[ui/**.js]
+indent_size = 2
+
+[ui/**.scss]
+indent_size = 4

--- a/pkg/mobile/bindableServices.go
+++ b/pkg/mobile/bindableServices.go
@@ -188,14 +188,39 @@ func attachCurrentBindings(lister *BindableMobileServiceCRUDLImpl, mobileClient 
 			for key, jsonString := range serviceConfigurationAnnotations {
 				if strings.Contains(key, "org.aerogear.binding."+serviceInstance.ObjectMeta.Name) {
 					bindableService.Configuration = append(bindableService.Configuration, jsonString)
+				} else if strings.Contains(key, "org.aerogear.binding-ext."+serviceInstance.ObjectMeta.Name){
+					// aerogear extended annotations
+					bindableService.ConfigurationExt = append(bindableService.ConfigurationExt, jsonString)
 				}
 			}
 		}
 	}
 
+	// remove duplicates in the config.
+	// in case of services that can have multiple bindings, we don't want to have duplicate elements.
+	bindableService.Configuration = removeDuplicatesUnordered(bindableService.Configuration)
+	bindableService.ConfigurationExt = removeDuplicatesUnordered(bindableService.ConfigurationExt)
+
 	bindableService.ServiceBinding = serviceBinding
 	return nil
 }
+
+func removeDuplicatesUnordered(elements []string) []string {
+	encountered := map[string]bool{}
+
+	// Create a map of all unique elements.
+	for v:= range elements {
+		encountered[elements[v]] = true
+	}
+
+	// Place all keys from the map into a slice.
+	result := []string{}
+	for key, _ := range encountered {
+		result = append(result, key)
+	}
+	return result
+}
+
 
 func attachServicePlan(bindableService *BindableMobileService, servicePlans *v1beta1.ClusterServicePlanList, csc *v1beta1.ClusterServiceClass) {
 	var servicePlan ServicePlan

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -25,16 +25,17 @@ type BuildConfigList = buildV1.BuildConfigList
 
 //BindableMobileService is the type that backs services on the Mobile Services page
 type BindableMobileService struct {
-	IsBound         bool                          `json:"isBound" validate:"required"`
-	Name            string                        `json:"name" validate:"required"`
-	ImageURL        string                        `json:"imageUrl,omitempty"`
-	IconClass       string                        `json:"iconClass,omitempty"`
-	Configuration   []string                      `json:"configuration,omitempty"`
-	ServiceInstance scv1beta1.ServiceInstance     `json:"serviceInstance,omitempty"`
-	ServiceBinding  scv1beta1.ServiceBinding      `json:"serviceBinding,omitempty"`
-	ServiceClass    scv1beta1.ClusterServiceClass `json:"serviceClass,omitempty"`
-	ServicePlan     ServicePlan                   `json:"servicePlan,omitempty"`
-	MobileClient    mcv1alpha1.MobileClient       `json:"mobileClient,omitempty"`
+	IsBound         	bool                          `json:"isBound" validate:"required"`
+	Name            	string                        `json:"name" validate:"required"`
+	ImageURL        	string                        `json:"imageUrl,omitempty"`
+	IconClass       	string                        `json:"iconClass,omitempty"`
+	Configuration   	[]string                      `json:"configuration,omitempty"`
+	ConfigurationExt	[]string                      `json:"configurationExt,omitempty"`
+	ServiceInstance 	scv1beta1.ServiceInstance     `json:"serviceInstance,omitempty"`
+	ServiceBinding  	scv1beta1.ServiceBinding      `json:"serviceBinding,omitempty"`
+	ServiceClass    	scv1beta1.ClusterServiceClass `json:"serviceClass,omitempty"`
+	ServicePlan     	ServicePlan                   `json:"servicePlan,omitempty"`
+	MobileClient    	mcv1alpha1.MobileClient       `json:"mobileClient,omitempty"`
 }
 
 //BindableMobileServiceList is a List of BindableMobileServices

--- a/ui/src/components/mobileservices/BindButton.js
+++ b/ui/src/components/mobileservices/BindButton.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+import { Button } from 'patternfly-react';
+
+class BindButton extends Component {
+  render() {
+    if (this.props.service.isBindingOperationInProgress()) {
+      return null;
+    }
+    return (
+      <Button className="bind-button" onClick={() => this.props.onClick()}>
+        Bind to App
+      </Button>
+    );
+  }
+}
+
+export default BindButton;

--- a/ui/src/components/mobileservices/BindingPanel.js
+++ b/ui/src/components/mobileservices/BindingPanel.js
@@ -90,45 +90,20 @@ export class BindingPanel extends Component {
   }
 
   hasUPSPlatformAnnotation(platform) {
-    // configExt field example value:
-    // it is an array of annotations that start with org.aerogear.binding-ext
-    // and our annotation's value is also an array
-    /*
-      [
-        [
-          {
-            "type": "android",
-            "typeLabel": "Android",
-            "url": "https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/d6f4836a-11df-42d1-a442-e9cc823715a4",
-            "id": "d6f4836a-11df-42d1-a442-e9cc823715a4"
-          }
-        ]
-      ]
-      */
     // there won't be any variant annotations if there is no binding yet
     if (!this.props.service.isBound()) {
       return false;
     }
 
-    const configExt = this.props.service.getConfigurationExt();
-
-    if (!configExt || !configExt.length) {
+    const configExtItems = this.props.service.getConfigurationExtAsJSON();
+    if (!configExtItems || !configExtItems.length) {
       return false;
     }
 
-    for (const configItemStr of configExt) {
-      let configExtItem;
-      try {
-        configExtItem = JSON.parse(configItemStr);
-      } catch (err) {
-        // not much we can do if the annotation is malformed
-        return false;
-      }
-      if (configExtItem && configExtItem.length && configExtItem.length > 0) {
-        for (const variantInfo of configExtItem) {
-          if (variantInfo.type === platform) {
-            return true;
-          }
+    for (const configExtItem of configExtItems) {
+      for (const variantInfo of configExtItem) {
+        if (variantInfo.type === platform) {
+          return true;
         }
       }
     }

--- a/ui/src/components/mobileservices/BindingPanel.js
+++ b/ui/src/components/mobileservices/BindingPanel.js
@@ -26,7 +26,7 @@ export class BindingPanel extends Component {
     const form = this.props.service.getFormDefinition();
     const { service } = this.props;
 
-    if (this.isUPSService()) {
+    if (this.props.service.isUPSService()) {
       const hasUPSAndroidAnnotation = this.hasUPSAndroidAnnotation();
       const hasUPSIOSAnnotation = this.hasUPSIOSAnnotation();
 
@@ -79,10 +79,6 @@ export class BindingPanel extends Component {
   show() {
     this.stepChanged(0);
     this.open();
-  }
-
-  isUPSService() {
-    return this.props.service.getServiceClassExternalName() === 'ups';
   }
 
   hasUPSAndroidAnnotation() {

--- a/ui/src/components/mobileservices/BindingPanel.js
+++ b/ui/src/components/mobileservices/BindingPanel.js
@@ -82,10 +82,7 @@ export class BindingPanel extends Component {
   }
 
   isUPSService(){
-    return this.props.service.serviceClass &&
-        this.props.service.serviceClass.spec &&
-        this.props.service.serviceClass.spec.data &&
-        this.props.service.serviceClass.spec.data.externalName === "ag-unifiedpush-apb";
+    return this.props.service.getServiceClassExternalName() === "ups";
   }
 
   hasUPSAndroidAnnotation(){

--- a/ui/src/components/mobileservices/BindingPanel.test.js
+++ b/ui/src/components/mobileservices/BindingPanel.test.js
@@ -8,7 +8,8 @@ describe('BindingPanel', () => {
   const service = {
     getName: () => 'Data Sync',
     getBindingSchema: () => 'http://json-schema.org/draft-04/schema',
-    getFormDefinition: () => 'CLIENT_ID'
+    getFormDefinition: () => 'CLIENT_ID',
+    isUPSService: () => false
   };
   it('should render the Wizard for binding the service', () => {
     const wrapper = shallow(<BindingPanel service={service} />);

--- a/ui/src/components/mobileservices/BindingStatus.js
+++ b/ui/src/components/mobileservices/BindingStatus.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import { ListView, Icon } from 'patternfly-react';
+
+class BindingStatus extends Component {
+  render() {
+    return (
+      <ListView.InfoItem key="bind-status">
+        {this.props.service.isBindingOperationInProgress() && (
+          <React.Fragment>
+            <Icon name="spinner" spin size="lg" />
+            {this.props.service.getBindingOperation()} In Progress
+          </React.Fragment>
+        )}
+        {this.props.service.isBindingOperationFailed() && (
+          <React.Fragment>
+            <Icon type="pf" name="error-circle-o" />
+            Operation Failed. Please Try Again Later.
+          </React.Fragment>
+        )}
+      </ListView.InfoItem>
+    );
+  }
+}
+
+export default BindingStatus;

--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
-import { ListView, ListViewItem, Row, Col, Button, Icon, DropdownKebab } from 'patternfly-react';
+import { ListViewItem, Row, Col, Button, DropdownKebab } from 'patternfly-react';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
 import DeleteItemButton from '../../containers/DeleteItemButton';
 import BindingPanel from './BindingPanel';
+import BindingStatus from './BindingStatus';
 
 function configurationView(configuration) {
   if (configuration.type === 'href') {
@@ -99,31 +100,16 @@ class BoundServiceRow extends Component {
     // check if the service is UPS.
     // binding status is not shown for other services in the BoundServiceRow view.
     // binding status is normally shown in UnboundServiceRow views.
-    if (!this.isUPSService()) {
+    if (!this.props.service.isUPSService()) {
       return null;
     }
 
-    return (
-      <ListView.InfoItem key="bind-status">
-        {this.props.service.isBindingOperationInProgress() && (
-          <React.Fragment>
-            <Icon name="spinner" spin size="lg" />
-            {this.props.service.getBindingOperation()} In Progress
-          </React.Fragment>
-        )}
-        {this.props.service.isBindingOperationFailed() && (
-          <React.Fragment>
-            <Icon type="pf" name="error-circle-o" />
-            Operation Failed. Please Try Again Later.
-          </React.Fragment>
-        )}
-      </ListView.InfoItem>
-    );
+    return <BindingStatus key={`${this.props.service.getId()}binding status`} service={this.props.service} />;
   }
 
   renderBindingButtons() {
     // check if the service is UPS. we only allow multiple bindings in case of UPS
-    if (!this.isUPSService()) {
+    if (!this.props.service.isUPSService()) {
       return null;
     }
     if (this.props.service.isBindingOperationInProgress()) {
@@ -151,10 +137,6 @@ class BoundServiceRow extends Component {
     );
   }
 
-  isUPSService() {
-    return this.props.service.getServiceClassExternalName() === 'ups';
-  }
-
   render() {
     return (
       <React.Fragment>
@@ -173,7 +155,7 @@ class BoundServiceRow extends Component {
         >
           {this.renderServiceDetails()}
         </ListViewItem>
-        {this.isUPSService() && (
+        {this.props.service.isUPSService() && (
           <BindingPanel
             service={this.props.service}
             showModal={this.state.showModal}

--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -150,10 +150,7 @@ class BoundServiceRow extends Component {
   }
 
   isUPSService(){
-    return this.props.service.serviceClass &&
-          this.props.service.serviceClass.spec &&
-          this.props.service.serviceClass.spec.data &&
-          this.props.service.serviceClass.spec.data.externalName === "ag-unifiedpush-apb";
+    return this.props.service.getServiceClassExternalName() === "ups";
   }
 
   render() {

--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -128,10 +128,8 @@ class BoundServiceRow extends Component {
         return null;
       }
     }
-    
-    return (
-      <BindButton service={this.props.service} onClick={() => this.setState({ showModal: true })} />
-    );
+
+    return <BindButton service={this.props.service} onClick={() => this.setState({ showModal: true })} />;
   }
 
   render() {

--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
-import { ListViewItem, Row, Col, Button, DropdownKebab } from 'patternfly-react';
+import { ListViewItem, Row, Col, DropdownKebab } from 'patternfly-react';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
 import DeleteItemButton from '../../containers/DeleteItemButton';
 import BindingPanel from './BindingPanel';
 import BindingStatus from './BindingStatus';
+import BindButton from './BindButton';
 
 function configurationView(configuration) {
   if (configuration.type === 'href') {
@@ -112,9 +113,6 @@ class BoundServiceRow extends Component {
     if (!this.props.service.isUPSService()) {
       return null;
     }
-    if (this.props.service.isBindingOperationInProgress()) {
-      return null;
-    }
     const configurationExt = this.props.service.getConfigurationExt();
     // sample value for configurationExt
     /*
@@ -130,10 +128,9 @@ class BoundServiceRow extends Component {
         return null;
       }
     }
+    
     return (
-      <Button className="bind-button" onClick={() => this.setState({ showModal: true })}>
-        Bind to App
-      </Button>
+      <BindButton service={this.props.service} onClick={() => this.setState({ showModal: true })} />
     );
   }
 

--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -113,18 +113,17 @@ class BoundServiceRow extends Component {
     if (!this.props.service.isUPSService()) {
       return null;
     }
-    const configurationExt = this.props.service.getConfigurationExt();
+    const configurationExt = this.props.service.getConfigurationExtAsJSON();
     // sample value for configurationExt
     /*
-      "[
+      [
         {"type":"ios","typeLabel":"iOS","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/c8d70b96-bd52-499c-845b-756089e06d36","id":"c8d70b96-bd52-499c-845b-756089e06d36"},
         {"type":"android","typeLabel":"Android","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f","id":"2d76d1eb-65ef-471c-8d21-75f80c3f370f"}
-      ]"
+      ]
     */
-    if (configurationExt) {
-      const configExtArray = JSON.parse(configurationExt);
-      // there are 2 variants already. can't create another variant.
-      if (configExtArray && configExtArray.length && configExtArray.length >= 2) {
+    if (configurationExt && configurationExt.length) {
+      if (configurationExt[0] && configurationExt[0].length && configurationExt[0].length >= 2) {
+        // there are 2 variants already. can't create another variant.
         return null;
       }
     }

--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -18,7 +18,7 @@ class BoundServiceRow extends Component {
     super(props);
 
     this.state = {
-        showModal: false
+      showModal: false
     };
 
     this.renderServiceBadge = this.renderServiceBadge.bind(this);
@@ -99,32 +99,32 @@ class BoundServiceRow extends Component {
     // check if the service is UPS.
     // binding status is not shown for other services in the BoundServiceRow view.
     // binding status is normally shown in UnboundServiceRow views.
-    if(!this.isUPSService()) {
-        return null;
+    if (!this.isUPSService()) {
+      return null;
     }
 
     return (
-        <ListView.InfoItem key="bind-status">
-            {this.props.service.isBindingOperationInProgress() && (
-                <React.Fragment>
-                    <Icon name="spinner" spin size="lg" />
-                    {this.props.service.getBindingOperation()} In Progress
-                </React.Fragment>
-            )}
-            {this.props.service.isBindingOperationFailed() && (
-                <React.Fragment>
-                    <Icon type="pf" name="error-circle-o" />
-                    Operation Failed. Please Try Again Later.
-                </React.Fragment>
-            )}
-        </ListView.InfoItem>
+      <ListView.InfoItem key="bind-status">
+        {this.props.service.isBindingOperationInProgress() && (
+          <React.Fragment>
+            <Icon name="spinner" spin size="lg" />
+            {this.props.service.getBindingOperation()} In Progress
+          </React.Fragment>
+        )}
+        {this.props.service.isBindingOperationFailed() && (
+          <React.Fragment>
+            <Icon type="pf" name="error-circle-o" />
+            Operation Failed. Please Try Again Later.
+          </React.Fragment>
+        )}
+      </ListView.InfoItem>
     );
   }
 
   renderBindingButtons() {
     // check if the service is UPS. we only allow multiple bindings in case of UPS
-    if(!this.isUPSService()) {
-        return null;
+    if (!this.isUPSService()) {
+      return null;
     }
     if (this.props.service.isBindingOperationInProgress()) {
       return null;
@@ -137,7 +137,7 @@ class BoundServiceRow extends Component {
         {"type":"android","typeLabel":"Android","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f","id":"2d76d1eb-65ef-471c-8d21-75f80c3f370f"}
       ]"
     */
-    if(configurationExt){
+    if (configurationExt) {
       const configExtArray = JSON.parse(configurationExt);
       // there are 2 variants already. can't create another variant.
       if (configExtArray && configExtArray.length && configExtArray.length >= 2) {
@@ -145,42 +145,44 @@ class BoundServiceRow extends Component {
       }
     }
     return (
-      <Button className="bind-button" onClick={() => this.setState({ showModal: true })}>Bind to App</Button>
+      <Button className="bind-button" onClick={() => this.setState({ showModal: true })}>
+        Bind to App
+      </Button>
     );
   }
 
-  isUPSService(){
-    return this.props.service.getServiceClassExternalName() === "ups";
+  isUPSService() {
+    return this.props.service.getServiceClassExternalName() === 'ups';
   }
 
   render() {
     return (
       <React.Fragment>
-      <ListViewItem
-        additionalInfo={[this.renderServiceBadge(), this.renderBindingStatus()]}
-        className="boundService"
-        actions={
-          <div>
-            {this.renderBindingButtons()}
-            <DropdownKebab id={`delete-${this.props.service.getBindingName()}`} pullRight>
-              <DeleteItemButton itemType="serviceBinding" itemName={this.props.service.getBindingName()} />
-            </DropdownKebab>
-          </div>
-        }
-        hideCloseIcon
-      >
-        {this.renderServiceDetails()}
-      </ListViewItem>
-          {this.isUPSService() &&
-            <BindingPanel
-                service={this.props.service}
-                showModal={this.state.showModal}
-                close={() => {
-                    this.setState({ showModal: false });
-                }}
-            />
+        <ListViewItem
+          additionalInfo={[this.renderServiceBadge(), this.renderBindingStatus()]}
+          className="boundService"
+          actions={
+            <div>
+              {this.renderBindingButtons()}
+              <DropdownKebab id={`delete-${this.props.service.getBindingName()}`} pullRight>
+                <DeleteItemButton itemType="serviceBinding" itemName={this.props.service.getBindingName()} />
+              </DropdownKebab>
+            </div>
           }
-    </React.Fragment>
+          hideCloseIcon
+        >
+          {this.renderServiceDetails()}
+        </ListViewItem>
+        {this.isUPSService() && (
+          <BindingPanel
+            service={this.props.service}
+            showModal={this.state.showModal}
+            close={() => {
+              this.setState({ showModal: false });
+            }}
+          />
+        )}
+      </React.Fragment>
     );
   }
 }

--- a/ui/src/components/mobileservices/BoundServiceRow.test.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.test.js
@@ -16,7 +16,7 @@ const store = {
 describe('BoundServiceRow - not UPS', () => {
   const service = {
     getConfiguration: () => undefined,
-    getConfigurationExt: () => undefined,
+    getConfigurationExtAsJSON: () => undefined,
     getDocumentationUrl: () => undefined,
     getBindingName: () => 'test-data-sync-r66b9',
     getIconClass: () => 'fa fa-refresh',
@@ -71,11 +71,27 @@ describe('BoundServiceRow - not UPS', () => {
 });
 
 describe('BoundServiceRow - UPS - 1 binding', () => {
+  const bindingSchema = {
+    properties: {
+      CLIENT_TYPE: {
+        default: 'Foo',
+        enum: ['Foo', 'Bar']
+      }
+    }
+  };
   const service = {
     getConfiguration: () => undefined,
-    getConfigurationExt: () => `[
-      {"type":"android","typeLabel":"Android","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f","id":"2d76d1eb-65ef-471c-8d21-75f80c3f370f"}
-    ]`,
+    getConfigurationExtAsJSON: () => [
+      [
+        {
+          type: 'android',
+          typeLabel: 'Android',
+          url:
+            'https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f',
+          id: '2d76d1eb-65ef-471c-8d21-75f80c3f370f'
+        }
+      ]
+    ],
     getDocumentationUrl: () => undefined,
     getBindingName: () => 'test-ups-r66b9',
     getIconClass: () => 'fa fa-something',
@@ -85,11 +101,11 @@ describe('BoundServiceRow - UPS - 1 binding', () => {
     isUPSService: () => true,
     isBindingOperationInProgress: () => false,
     isBindingOperationFailed: () => false,
-    getBindingSchema: () => undefined,
+    getBindingSchema: () => bindingSchema,
     getFormDefinition: () => undefined,
     isBound: () => true
   };
-  it('should render the bind button', () => {
+  it('should render the bind button, binding status and update the bind panel platform selection', () => {
     const wrapper = mount(
       <Provider store={store} key="provider">
         <BrowserRouter>
@@ -98,26 +114,41 @@ describe('BoundServiceRow - UPS - 1 binding', () => {
       </Provider>
     );
     expect(wrapper.find('BindButton')).toHaveLength(1);
-  });
-  it('should render the binding status', () => {
-    const wrapper = mount(
-      <Provider store={store} key="provider">
-        <BrowserRouter>
-          <BoundServiceRow service={service} />
-        </BrowserRouter>
-      </Provider>
-    );
     expect(wrapper.find('BindingStatus')).toHaveLength(1);
+    expect(bindingSchema.properties.CLIENT_TYPE.default).toEqual('IOS');
+    expect(bindingSchema.properties.CLIENT_TYPE.enum).toEqual(['IOS']);
   });
 });
 
 describe('BoundServiceRow - UPS - 2 bindings', () => {
+  const bindingSchema = {
+    properties: {
+      CLIENT_TYPE: {
+        default: 'Foo',
+        enum: ['Foo', 'Bar']
+      }
+    }
+  };
   const service = {
     getConfiguration: () => undefined,
-    getConfigurationExt: () => `[
-      {"type":"android","typeLabel":"Android","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f","id":"2d76d1eb-65ef-471c-8d21-75f80c3f370f"},
-      {"type":"ios","typeLabel":"iOS","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/c8d70b96-bd52-499c-845b-756089e06d36","id":"c8d70b96-bd52-499c-845b-756089e06d36"}
-    ]`,
+    getConfigurationExtAsJSON: () => [
+      [
+        {
+          type: 'android',
+          typeLabel: 'Android',
+          url:
+            'https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f',
+          id: '2d76d1eb-65ef-471c-8d21-75f80c3f370f'
+        },
+        {
+          type: 'ios',
+          typeLabel: 'iOS',
+          url:
+            'https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/c8d70b96-bd52-499c-845b-756089e06d36',
+          id: 'c8d70b96-bd52-499c-845b-756089e06d36'
+        }
+      ]
+    ],
     getDocumentationUrl: () => undefined,
     getBindingName: () => 'test-ups-r66b9',
     getIconClass: () => 'fa fa-something',
@@ -127,11 +158,11 @@ describe('BoundServiceRow - UPS - 2 bindings', () => {
     isUPSService: () => true,
     isBindingOperationInProgress: () => false,
     isBindingOperationFailed: () => false,
-    getBindingSchema: () => undefined,
+    getBindingSchema: () => bindingSchema,
     getFormDefinition: () => undefined,
     isBound: () => true
   };
-  it('should not render the bind button', () => {
+  it('should not render the bind button, render the binding status and not update the bind panel platform selection', () => {
     const wrapper = mount(
       <Provider store={store} key="provider">
         <BrowserRouter>
@@ -140,17 +171,10 @@ describe('BoundServiceRow - UPS - 2 bindings', () => {
       </Provider>
     );
     expect(wrapper.find('BindButton')).toHaveLength(0);
-  });
-  it('should render the binding status', () => {
     // normally we show the binding status in the UnboundServiceRow, not in the bound one.
     // but, as there might be a binding in progress, we still need to show this status in BoundServiceRow too
-    const wrapper = mount(
-      <Provider store={store} key="provider">
-        <BrowserRouter>
-          <BoundServiceRow service={service} />
-        </BrowserRouter>
-      </Provider>
-    );
     expect(wrapper.find('BindingStatus')).toHaveLength(1);
+    expect(bindingSchema.properties.CLIENT_TYPE.default).toEqual('Foo');
+    expect(bindingSchema.properties.CLIENT_TYPE.enum).toEqual(['Foo', 'Bar']);
   });
 });

--- a/ui/src/components/mobileservices/BoundServiceRow.test.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.test.js
@@ -8,12 +8,14 @@ import BoundServiceRow from './BoundServiceRow';
 describe('BoundServiceRow', () => {
   const service = {
     getConfiguration: () => undefined,
+    getConfigurationExt: () => undefined,
     getDocumentationUrl: () => undefined,
     getBindingName: () => 'test-data-sync-r66b9',
     getIconClass: () => 'fa fa-refresh',
     getId: () => 'Data Sync',
     getLogoUrl: () => undefined,
-    getName: () => 'Data Sync'
+    getName: () => 'Data Sync',
+    isUPSService: () => false
   };
   it('should render the row with bound service', () => {
     const wrapper = shallow(<BoundServiceRow service={service} />);

--- a/ui/src/components/mobileservices/BoundServiceRow.test.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.test.js
@@ -1,11 +1,19 @@
 /* eslint guard-for-in: 0 */
 
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 
 import BoundServiceRow from './BoundServiceRow';
 
-describe('BoundServiceRow', () => {
+const store = {
+  subscribe: jest.fn(),
+  dispatch: jest.fn(),
+  getState: jest.fn()
+};
+
+describe('BoundServiceRow - not UPS', () => {
   const service = {
     getConfiguration: () => undefined,
     getConfigurationExt: () => undefined,
@@ -39,5 +47,110 @@ describe('BoundServiceRow', () => {
     ];
     const wrapper = shallow(<BoundServiceRow service={service} />);
     expect(wrapper.find(`a[href="${configurationUrl}"]`).text()).toEqual(configurationUrl);
+  });
+  it('should not render the bind button', () => {
+    const wrapper = mount(
+      <Provider store={store} key="provider">
+        <BrowserRouter>
+          <BoundServiceRow service={service} />
+        </BrowserRouter>
+      </Provider>
+    );
+    expect(wrapper.find('BindButton')).toHaveLength(0);
+  });
+  it('should not render the binding status', () => {
+    const wrapper = mount(
+      <Provider store={store} key="provider">
+        <BrowserRouter>
+          <BoundServiceRow service={service} />
+        </BrowserRouter>
+      </Provider>
+    );
+    expect(wrapper.find('BindingStatus')).toHaveLength(0);
+  });
+});
+
+describe('BoundServiceRow - UPS - 1 binding', () => {
+  const service = {
+    getConfiguration: () => undefined,
+    getConfigurationExt: () => `[
+      {"type":"android","typeLabel":"Android","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f","id":"2d76d1eb-65ef-471c-8d21-75f80c3f370f"}
+    ]`,
+    getDocumentationUrl: () => undefined,
+    getBindingName: () => 'test-ups-r66b9',
+    getIconClass: () => 'fa fa-something',
+    getId: () => 'UPS',
+    getLogoUrl: () => undefined,
+    getName: () => 'UPS',
+    isUPSService: () => true,
+    isBindingOperationInProgress: () => false,
+    isBindingOperationFailed: () => false,
+    getBindingSchema: () => undefined,
+    getFormDefinition: () => undefined,
+    isBound: () => true
+  };
+  it('should render the bind button', () => {
+    const wrapper = mount(
+      <Provider store={store} key="provider">
+        <BrowserRouter>
+          <BoundServiceRow service={service} />
+        </BrowserRouter>
+      </Provider>
+    );
+    expect(wrapper.find('BindButton')).toHaveLength(1);
+  });
+  it('should render the binding status', () => {
+    const wrapper = mount(
+      <Provider store={store} key="provider">
+        <BrowserRouter>
+          <BoundServiceRow service={service} />
+        </BrowserRouter>
+      </Provider>
+    );
+    expect(wrapper.find('BindingStatus')).toHaveLength(1);
+  });
+});
+
+describe('BoundServiceRow - UPS - 2 bindings', () => {
+  const service = {
+    getConfiguration: () => undefined,
+    getConfigurationExt: () => `[
+      {"type":"android","typeLabel":"Android","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f","id":"2d76d1eb-65ef-471c-8d21-75f80c3f370f"},
+      {"type":"ios","typeLabel":"iOS","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/c8d70b96-bd52-499c-845b-756089e06d36","id":"c8d70b96-bd52-499c-845b-756089e06d36"}
+    ]`,
+    getDocumentationUrl: () => undefined,
+    getBindingName: () => 'test-ups-r66b9',
+    getIconClass: () => 'fa fa-something',
+    getId: () => 'UPS',
+    getLogoUrl: () => undefined,
+    getName: () => 'UPS',
+    isUPSService: () => true,
+    isBindingOperationInProgress: () => false,
+    isBindingOperationFailed: () => false,
+    getBindingSchema: () => undefined,
+    getFormDefinition: () => undefined,
+    isBound: () => true
+  };
+  it('should not render the bind button', () => {
+    const wrapper = mount(
+      <Provider store={store} key="provider">
+        <BrowserRouter>
+          <BoundServiceRow service={service} />
+        </BrowserRouter>
+      </Provider>
+    );
+    expect(wrapper.find('BindButton')).toHaveLength(0);
+  });
+  it('should render the binding status', () => {
+    // normally we show the binding status in the UnboundServiceRow, not in the bound one.
+    // but, as there might be a binding in progress, we still need to show this status in BoundServiceRow too
+    const wrapper = mount(
+      <Provider store={store} key="provider">
+        <BrowserRouter>
+          <BoundServiceRow service={service} />
+        </BrowserRouter>
+      </Provider>
+    );
+    expect(wrapper.find('BindingStatus')).toHaveLength(1);
   });
 });

--- a/ui/src/components/mobileservices/MobileServiceView.js
+++ b/ui/src/components/mobileservices/MobileServiceView.js
@@ -20,7 +20,7 @@ class MobileServiceView extends Component {
         {this.props.boundServices && this.props.boundServices.length > 0 ? (
           this.props.boundServices.map(service => {
             this.setDefaultBindingProperties(service);
-            return <BoundServiceRow key={service.getId()} service={service} />
+            return <BoundServiceRow key={service.getId()} service={service} />;
           })
         ) : (
           <EmptyState>There are no bound services.</EmptyState>

--- a/ui/src/components/mobileservices/MobileServiceView.js
+++ b/ui/src/components/mobileservices/MobileServiceView.js
@@ -18,7 +18,10 @@ class MobileServiceView extends Component {
       <React.Fragment>
         <h2 key="bound-services">Bound Services</h2>
         {this.props.boundServices && this.props.boundServices.length > 0 ? (
-          this.props.boundServices.map(service => <BoundServiceRow key={service.getId()} service={service} />)
+          this.props.boundServices.map(service => {
+            this.setDefaultBindingProperties(service);
+            return <BoundServiceRow key={service.getId()} service={service} />
+          })
         ) : (
           <EmptyState>There are no bound services.</EmptyState>
         )}

--- a/ui/src/components/mobileservices/MobileServiceView.js
+++ b/ui/src/components/mobileservices/MobileServiceView.js
@@ -10,7 +10,7 @@ class MobileServiceView extends Component {
     super(props);
     this.boundServiceRows = this.boundServiceRows.bind(this);
     this.unboundServiceRows = this.unboundServiceRows.bind(this);
-    this.setDefaultBindingProperties = this.setDefaultBindingProperties.bind(this);
+    this.addDefaultBindingProperty = this.addDefaultBindingProperty.bind(this);
   }
 
   boundServiceRows() {
@@ -19,7 +19,7 @@ class MobileServiceView extends Component {
         <h2 key="bound-services">Bound Services</h2>
         {this.props.boundServices && this.props.boundServices.length > 0 ? (
           this.props.boundServices.map(service => {
-            this.setDefaultBindingProperties(service);
+            this.addDefaultBindingProperty(service);
             return <BoundServiceRow key={service.getId()} service={service} />;
           })
         ) : (
@@ -35,7 +35,7 @@ class MobileServiceView extends Component {
         <h2 key="unbound-services">Unbound Services</h2>
         {this.props.unboundServices && this.props.unboundServices.length > 0 ? (
           this.props.unboundServices.map(service => {
-            this.setDefaultBindingProperties(service);
+            this.addDefaultBindingProperty(service);
             return <UnboundServiceRow key={service.getId()} service={service} />;
           })
         ) : (
@@ -50,7 +50,7 @@ class MobileServiceView extends Component {
   }
 
   // This makes the field in the binding form set to the mobile client name
-  setDefaultBindingProperties(service) {
+  addDefaultBindingProperty(service) {
     service.setBindingSchemaDefaultValues('CLIENT_ID', this.props.appName);
   }
 

--- a/ui/src/components/mobileservices/ServiceRow.scss
+++ b/ui/src/components/mobileservices/ServiceRow.scss
@@ -3,12 +3,24 @@
     font-weight: 700;
 }
 
-.boundService .list-group-item-header {
-    background-color: #ededed;
-    border-color: #bbb;
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
+.boundService {
+    .list-group-item-header {
+        background-color: #ededed;
+        border-color: #bbb;
+        border-bottom-width: 1px;
+        border-bottom-style: solid;
+    }
+    .bind-button{
+        margin-right: 10px;
+    }
 }
+
+.unboundService {
+    .bind-button{
+        margin-right: 25px;
+    }
+}
+
 .list-group-item .logo {
     width: 30px;
     height: 30px;

--- a/ui/src/components/mobileservices/UnboundServiceRow.js
+++ b/ui/src/components/mobileservices/UnboundServiceRow.js
@@ -67,7 +67,7 @@ class UnboundServiceRow extends Component {
     }
     return (
       <div>
-        <Button onClick={() => this.setState({ showModal: true })}>Bind to App</Button>
+        <Button className="bind-button" onClick={() => this.setState({ showModal: true })}>Bind to App</Button>
       </div>
     );
   }
@@ -77,6 +77,7 @@ class UnboundServiceRow extends Component {
       <React.Fragment>
         <ListViewItem
           additionalInfo={[this.renderServiceBadge(), this.renderBindingStatus()]}
+          className="unboundService"
           actions={this.renderBindingButtons()}
         />
         <BindingPanel

--- a/ui/src/components/mobileservices/UnboundServiceRow.js
+++ b/ui/src/components/mobileservices/UnboundServiceRow.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
-import { ListViewItem, Col, Button } from 'patternfly-react';
+import { ListViewItem, Col } from 'patternfly-react';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
 import BindingPanel from './BindingPanel';
 import BindingStatus from './BindingStatus';
+import BindButton from './BindButton';
 
 class UnboundServiceRow extends Component {
   constructor(props) {
@@ -48,14 +49,9 @@ class UnboundServiceRow extends Component {
   }
 
   renderBindingButtons() {
-    if (this.props.service.isBindingOperationInProgress()) {
-      return null;
-    }
     return (
       <div>
-        <Button className="bind-button" onClick={() => this.setState({ showModal: true })}>
-          Bind to App
-        </Button>
+        <BindButton service={this.props.service} onClick={() => this.setState({ showModal: true })} />
       </div>
     );
   }

--- a/ui/src/components/mobileservices/UnboundServiceRow.js
+++ b/ui/src/components/mobileservices/UnboundServiceRow.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
-import { ListView, ListViewItem, Col, Button, Icon } from 'patternfly-react';
+import { ListViewItem, Col, Button } from 'patternfly-react';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
 import BindingPanel from './BindingPanel';
+import BindingStatus from './BindingStatus';
 
 class UnboundServiceRow extends Component {
   constructor(props) {
@@ -43,22 +44,7 @@ class UnboundServiceRow extends Component {
   }
 
   renderBindingStatus() {
-    return (
-      <ListView.InfoItem key="bind-status">
-        {this.props.service.isBindingOperationInProgress() && (
-          <React.Fragment>
-            <Icon name="spinner" spin size="lg" />
-            {this.props.service.getBindingOperation()} In Progress
-          </React.Fragment>
-        )}
-        {this.props.service.isBindingOperationFailed() && (
-          <React.Fragment>
-            <Icon type="pf" name="error-circle-o" />
-            Operation Failed. Please Try Again Later.
-          </React.Fragment>
-        )}
-      </ListView.InfoItem>
-    );
+    return <BindingStatus key={`${this.props.service.getId()}binding status`} service={this.props.service} />;
   }
 
   renderBindingButtons() {

--- a/ui/src/components/mobileservices/UnboundServiceRow.js
+++ b/ui/src/components/mobileservices/UnboundServiceRow.js
@@ -67,7 +67,9 @@ class UnboundServiceRow extends Component {
     }
     return (
       <div>
-        <Button className="bind-button" onClick={() => this.setState({ showModal: true })}>Bind to App</Button>
+        <Button className="bind-button" onClick={() => this.setState({ showModal: true })}>
+          Bind to App
+        </Button>
       </div>
     );
   }

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -5,10 +5,12 @@ export class MobileService {
   constructor(json = {}) {
     this.data = json;
     this.configuration = this.data.configuration || [];
+    this.configurationExt = this.data.configurationExt || [];
     this.setupText = '';
     this.serviceInstance = new Resource(this.data.serviceInstance);
     this.serviceBinding = new Resource(this.data.serviceBinding);
     this.serviceClass = new Resource(this.data.serviceClass);
+    this.servicePlan = new Resource(this.data.servicePlan);
   }
 
   getName() {
@@ -47,10 +49,55 @@ export class MobileService {
     return this.setupText;
   }
 
+  getBindingSchema() {
+    return this.servicePlan.spec.get('serviceBindingCreateParameterSchema');
+  }
+
+  isBindingOperationInProgress() {
+      const conditions = this.serviceBinding.status.get('conditions');
+      // the bind operation could be in-flight. In this case, the operation is neither ready, or failed.
+      if (conditions && find(conditions, { type: 'Ready', status: 'False' }) && !this.isBindingOperationFailed()) {
+          return true;
+      }
+      return false;
+  }
+
+  getBindingOperation() {
+      return this.serviceBinding.status.get('currentOperation');
+  }
+
+  isBindingOperationFailed() {
+      const conditions = this.serviceBinding.status.get('conditions');
+      if (conditions && find(conditions, { type: 'Failed', status: 'True' })) {
+          return true;
+      }
+      return false;
+  }
+
+  getFormDefinition() {
+    const form = this.servicePlan.spec.get('externalMetadata.schemas.service_binding.create.openshift_form_definition');
+    form.filterDisplayGroupBy = JSON.parse(
+      this.servicePlan.spec.get('externalMetadata.mobileclient_bind_parameters_data[0]') || ''
+    ).filterDisplayGroupBy;
+    return form;
+  }
+
+  setBindingSchemaDefaultValues(name, value) {
+    const bindingSchema = this.getBindingSchema();
+    if (bindingSchema && bindingSchema.properties && bindingSchema.properties[name]) {
+      bindingSchema.properties[name].default = value;
+    }
+  }
+
+  getServiceClassExternalName() {
+    return this.serviceClass.spec.get('externalMetadata.serviceName');
+  }
+
   toJSON() {
     return {
       ...this.data,
       configuration: this.configuration,
+      configurationExt: this.configurationExt,
       serviceInstance: this.serviceInstance.toJSON(),
       serviceBinding: this.serviceBinding.toJSON(),
       serviceClass: this.serviceClass.toJSON()
@@ -66,6 +113,10 @@ export class BoundMobileService extends MobileService {
   getConfiguration() {
     return this.data.configuration;
   }
+
+    getConfigurationExt() {
+        return this.data.configurationExt;
+    }
 
   getDocumentationUrl() {
     return this.serviceClass.spec.get('externalMetadata.documentationUrl');
@@ -87,51 +138,6 @@ export class BoundMobileService extends MobileService {
 export class UnboundMobileService extends MobileService {
   constructor(json = {}) {
     super(json);
-    this.servicePlan = new Resource(this.data.servicePlan);
-  }
-
-  getBindingSchema() {
-    return this.servicePlan.spec.get('serviceBindingCreateParameterSchema');
-  }
-
-  setBindingSchemaDefaultValues(name, value) {
-    const bindingSchema = this.getBindingSchema();
-    if (bindingSchema && bindingSchema.properties && bindingSchema.properties[name]) {
-      bindingSchema.properties[name].default = value;
-    }
-  }
-
-  getFormDefinition() {
-    const form = this.servicePlan.spec.get('externalMetadata.schemas.service_binding.create.openshift_form_definition');
-    form.filterDisplayGroupBy = JSON.parse(
-      this.servicePlan.spec.get('externalMetadata.mobileclient_bind_parameters_data[0]') || ''
-    ).filterDisplayGroupBy;
-    return form;
-  }
-
-  getServiceClassExternalName() {
-    return this.serviceClass.spec.get('externalMetadata.serviceName');
-  }
-
-  isBindingOperationInProgress() {
-    const conditions = this.serviceBinding.status.get('conditions');
-    // the bind operation could be in-flight. In this case, the operation is neither ready, or failed.
-    if (conditions && find(conditions, { type: 'Ready', status: 'False' }) && !this.isBindingOperationFailed()) {
-      return true;
-    }
-    return false;
-  }
-
-  getBindingOperation() {
-    return this.serviceBinding.status.get('currentOperation');
-  }
-
-  isBindingOperationFailed() {
-    const conditions = this.serviceBinding.status.get('conditions');
-    if (conditions && find(conditions, { type: 'Failed', status: 'True' })) {
-      return true;
-    }
-    return false;
   }
 
   /**

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -114,9 +114,9 @@ export class BoundMobileService extends MobileService {
     return this.data.configuration;
   }
 
-    getConfigurationExt() {
-        return this.data.configurationExt;
-    }
+  getConfigurationExt() {
+    return this.data.configurationExt;
+  }
 
   getDocumentationUrl() {
     return this.serviceClass.spec.get('externalMetadata.documentationUrl');

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -127,6 +127,17 @@ export class BoundMobileService extends MobileService {
   }
 
   /**
+   * This method returns a new instance of BoundMobileService, with a status of 'Binding in progress'
+   * @returns {BoundMobileService}
+   */
+  markBindInProgress() {
+    return new BoundMobileService({
+      ...this.data,
+      serviceBinding: { status: { currentOperation: 'Binding', conditions: [{ type: 'Ready', status: 'False' }] } }
+    });
+  }
+
+  /**
    * This method returns an instance of 'UnboundMobileService' with a state of 'Unbinding in progress'
    * @returns {UnboundMobileService}
    */

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -122,6 +122,42 @@ export class BoundMobileService extends MobileService {
     return this.data.configurationExt;
   }
 
+  getConfigurationExtAsJSON() {
+    // configExt field example value:
+    // it is an array of annotations that start with org.aerogear.binding-ext
+    // and our annotation's value is also an array
+    /*
+      [
+        [
+          {
+            "type": "android",
+            "typeLabel": "Android",
+            "url": "https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/d6f4836a-11df-42d1-a442-e9cc823715a4",
+            "id": "d6f4836a-11df-42d1-a442-e9cc823715a4"
+          }
+        ]
+      ]
+      */
+    if (!this.data.configurationExt || !this.data.configurationExt.length) {
+      return undefined;
+    }
+
+    const configExtItems = [];
+
+    for (const configItemStr of this.data.configurationExt) {
+      let configExtItem;
+      try {
+        configExtItem = JSON.parse(configItemStr);
+        configExtItems.push(configExtItem);
+      } catch (err) {
+        // not much we can do if the annotation is malformed
+        console.warn('ConfigurationExt item is malformed', configItemStr);
+      }
+    }
+
+    return configExtItems;
+  }
+
   getDocumentationUrl() {
     return this.serviceClass.spec.get('externalMetadata.documentationUrl');
   }

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -54,24 +54,24 @@ export class MobileService {
   }
 
   isBindingOperationInProgress() {
-      const conditions = this.serviceBinding.status.get('conditions');
-      // the bind operation could be in-flight. In this case, the operation is neither ready, or failed.
-      if (conditions && find(conditions, { type: 'Ready', status: 'False' }) && !this.isBindingOperationFailed()) {
-          return true;
-      }
-      return false;
+    const conditions = this.serviceBinding.status.get('conditions');
+    // the bind operation could be in-flight. In this case, the operation is neither ready, or failed.
+    if (conditions && find(conditions, { type: 'Ready', status: 'False' }) && !this.isBindingOperationFailed()) {
+      return true;
+    }
+    return false;
   }
 
   getBindingOperation() {
-      return this.serviceBinding.status.get('currentOperation');
+    return this.serviceBinding.status.get('currentOperation');
   }
 
   isBindingOperationFailed() {
-      const conditions = this.serviceBinding.status.get('conditions');
-      if (conditions && find(conditions, { type: 'Failed', status: 'True' })) {
-          return true;
-      }
-      return false;
+    const conditions = this.serviceBinding.status.get('conditions');
+    if (conditions && find(conditions, { type: 'Failed', status: 'True' })) {
+      return true;
+    }
+    return false;
   }
 
   getFormDefinition() {

--- a/ui/src/models/mobileservices/mobileservice.js
+++ b/ui/src/models/mobileservices/mobileservice.js
@@ -93,6 +93,10 @@ export class MobileService {
     return this.serviceClass.spec.get('externalMetadata.serviceName');
   }
 
+  isUPSService() {
+    return this.getServiceClassExternalName() === 'ups';
+  }
+
   toJSON() {
     return {
       ...this.data,

--- a/ui/src/reducers/serviceBindings.js
+++ b/ui/src/reducers/serviceBindings.js
@@ -76,7 +76,7 @@ const serviceBindingsReducer = (state = defaultState, action) => {
         isCreating: false,
         unboundServices: [
           ...state.unboundServices.slice(0, index),
-          state.unboundServices[index].bind(),
+          state.unboundServices[index].bind(), // TODO: what about multiple binding support?
           ...state.unboundServices.slice(index + 1)
         ],
         errors: getErrors(null, 'create', state.errors)
@@ -101,8 +101,8 @@ const serviceBindingsReducer = (state = defaultState, action) => {
       return {
         ...state,
         isDeleting: false,
-        boundServices: [...state.boundServices.slice(0, index), ...state.boundServices.slice(index + 1)],
-        unboundServices: [...state.unboundServices, state.boundServices[index].unbind()],
+        boundServices: [...state.boundServices.slice(0, index), ...state.boundServices.slice(index + 1)], // TODO: what about multiple binding support?
+        unboundServices: [...state.unboundServices, state.boundServices[index].unbind()], // TODO: what about multiple binding support?
         errors: getErrors(null, 'delete', state.errors)
       };
     }

--- a/ui/src/reducers/serviceBindings.js
+++ b/ui/src/reducers/serviceBindings.js
@@ -89,25 +89,25 @@ const serviceBindingsReducer = (state = defaultState, action) => {
         };
 
         return newState;
-      } else {
-        const indexOfBoundService = findIndex(
-          state.boundServices,
-          binding => binding.getServiceInstanceName() === serviceInstanceName
-        );
-
-        const newState = {
-          ...state,
-          isCreating: false,
-          boundServices: [
-            ...state.boundServices.slice(0, indexOfBoundService),
-            state.boundServices[indexOfBoundService].markBindInProgress(),
-            ...state.boundServices.slice(indexOfBoundService + 1)
-          ],
-          errors: getErrors(null, 'create', state.errors)
-        };
-
-        return newState;
       }
+
+      const indexOfBoundService = findIndex(
+        state.boundServices,
+        binding => binding.getServiceInstanceName() === serviceInstanceName
+      );
+
+      const newState = {
+        ...state,
+        isCreating: false,
+        boundServices: [
+          ...state.boundServices.slice(0, indexOfBoundService),
+          state.boundServices[indexOfBoundService].markBindInProgress(),
+          ...state.boundServices.slice(indexOfBoundService + 1)
+        ],
+        errors: getErrors(null, 'create', state.errors)
+      };
+
+      return newState;
     }
     case SERVICE_BINDING_CREATE_FAILURE:
       return {

--- a/ui/src/reducers/serviceBindings.test.js
+++ b/ui/src/reducers/serviceBindings.test.js
@@ -129,6 +129,24 @@ describe('Create Binding', () => {
     expect(unboundService.getBindingOperation()).toBe('Binding');
   });
 
+  it('test create success in case of multiple bindings', () => {
+    const initialState = {
+      ...getInitialState(),
+      boundServices: [createTestBoundService('test-instance')]
+    };
+
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDING_CREATE_SUCCESS,
+      result: { serviceInstanceName: 'test-instance' }
+    });
+    expect(newState.isCreating).toBe(false);
+    expect(newState.unboundServices).toHaveLength(0);
+    expect(newState.boundServices).toHaveLength(1);
+    const unboundService = newState.boundServices[0];
+    expect(unboundService.isBindingOperationInProgress()).toBe(true);
+    expect(unboundService.getBindingOperation()).toBe('Binding');
+  });
+
   it('test create failure', () => {
     const initialState = {
       ...getInitialState(),
@@ -141,6 +159,23 @@ describe('Create Binding', () => {
     });
     expect(newState.isCreating).toBe(false);
     expect(newState.unboundServices).toHaveLength(1);
+    expect(newState.errors).toHaveLength(1);
+    expect(newState.errors[0]).toEqual({ error: 'service binding test error', type: 'create' });
+  });
+
+  it('test create failure  in case of multiple bindings', () => {
+    const initialState = {
+      ...getInitialState(),
+      boundServices: [createTestBoundService('test-instance')]
+    };
+
+    const newState = serviceBindingReducer(initialState, {
+      type: SERVICE_BINDING_CREATE_FAILURE,
+      error: 'service binding test error'
+    });
+    expect(newState.isCreating).toBe(false);
+    expect(newState.unboundServices).toHaveLength(0);
+    expect(newState.boundServices).toHaveLength(1);
     expect(newState.errors).toHaveLength(1);
     expect(newState.errors[0]).toEqual({ error: 'service binding test error', type: 'create' });
   });


### PR DESCRIPTION
How to verify:
- Make sure you have the latest UPS apb. If not, change metadata of UPS apb to https://github.com/aerogearcatalog/unifiedpush-apb/blob/master/apb.yml#L32 via `oc edit clusterserviceplan`
- Start this project, Provision UPS, provision Metrics
- Create a client and bind to UPS
- You will still see the Bind button next to UPS, but not for e.g. Metrics when you bind to Metrics
- Press Bind button next to UPS again
- You will only see the missing platform, Android or IOS, in the platform select box
- Create the binding
- You won't see the Bind button next to UPS anymore
- Also test things like "Binding in Progress" status display, etc.

What's missing:
- Delete button adaption for multiple bindings. Will be done separately within a task from https://issues.jboss.org/browse/AEROGEAR-8153