### PR TITLE
Fixed watching for resources in UI

### DIFF
--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -52,12 +52,11 @@ class BoundServiceRow extends Component {
       documentationFragment = (
         <Row>
           <Col md={2} className="detailsKey">
-            Documentation :
+            Documentation:
           </Col>
           <Col md={4} className="detailsValue">
             <a href={this.props.service.getDocumentationUrl()}>
-              SDK Setup
-              <i className="fa fa-external-link" aria-hidden="true" />
+              SDK Setup <i className="fa fa-external-link" aria-hidden="true" />
             </a>
           </Col>
         </Row>
@@ -71,7 +70,7 @@ class BoundServiceRow extends Component {
         return (
           <Row key={configuration.label}>
             <Col md={2} className="detailsKey">
-              {configuration.label} :
+              {configuration.label}:
             </Col>
             <Col md={4} className="detailsValue">
               {configurationView(configuration)}

--- a/ui/src/components/mobileservices/BoundServiceRow.test.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.test.js
@@ -23,7 +23,7 @@ describe('BoundServiceRow', () => {
   it('should display documentation URL in the service row', () => {
     service.getDocumentationUrl = () => 'http://test-url.com';
     const wrapper = shallow(<BoundServiceRow service={service} />);
-    expect(wrapper.find(`a[href="${service.getDocumentationUrl()}"]`).text()).toEqual('SDK Setup');
+    expect(wrapper.find(`a[href="${service.getDocumentationUrl()}"]`).text()).toEqual('SDK Setup ');
   });
 
   it('should display configuration details in the service row', () => {

--- a/ui/src/components/mobileservices/MobileServiceView.js
+++ b/ui/src/components/mobileservices/MobileServiceView.js
@@ -3,8 +3,6 @@ import { EmptyState, Spinner } from 'patternfly-react';
 import { connect } from 'react-redux';
 import BoundServiceRow from './BoundServiceRow';
 import UnboundServiceRow from './UnboundServiceRow';
-import { fetchBindings } from '../../actions/serviceBinding';
-import DataService from '../../DataService';
 import './MobileServiceView.css';
 
 class MobileServiceView extends Component {
@@ -13,17 +11,6 @@ class MobileServiceView extends Component {
     this.boundServiceRows = this.boundServiceRows.bind(this);
     this.unboundServiceRows = this.unboundServiceRows.bind(this);
     this.setDefaultBindingProperties = this.setDefaultBindingProperties.bind(this);
-  }
-
-  componentDidMount() {
-    this.props.fetchBindings(this.props.appName);
-    this.wsBindings = DataService.watchBindableServices(this.props.appName, () => {
-      this.props.fetchBindings(this.props.appName);
-    });
-  }
-
-  componentWillUnmount() {
-    this.wsServices && this.wsServices.close();
   }
 
   boundServiceRows() {
@@ -65,10 +52,13 @@ class MobileServiceView extends Component {
   }
 
   render() {
-    const { isReading = true } = this.props;
+    const { isReading = true, boundServices, unboundServices } = this.props;
     return (
       <div className="mobile-service-view">
-        <Spinner loading={isReading} className="spinner-padding">
+        <Spinner
+          loading={isReading && boundServices.length === 0 && unboundServices.length === 0}
+          className="spinner-padding"
+        >
           {this.boundServiceRows()}
           {this.unboundServiceRows()}
         </Spinner>
@@ -81,11 +71,4 @@ function mapStateToProps(state) {
   return state.serviceBindings;
 }
 
-const mapDispatchToProps = {
-  fetchBindings
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(MobileServiceView);
+export default connect(mapStateToProps)(MobileServiceView);

--- a/ui/src/containers/Client.js
+++ b/ui/src/containers/Client.js
@@ -26,6 +26,8 @@ import { MobileApp } from '../models';
 import { MobileClientBuildOverviewList } from '../components/build/MobileClientBuildOverviewList';
 import BuildConfigDialog from './BuildConfigDialog';
 import './Client.css';
+import { fetchBindings } from '../actions/serviceBinding';
+import { fetchServices } from '../actions/services';
 
 export const TAB_CONFIGURATION = { key: 1, hash: 'configuration' };
 export const TAB_MOBILE_SERVICES = { key: 2, hash: 'services' };
@@ -61,11 +63,21 @@ export class Client extends Component {
       this.wsBuildConfigs = DataService.watchBuildConfigs(this.props.fetchBuildConfigs);
       this.wsBuilds = DataService.watchBuilds(this.props.fetchBuilds);
     }
+
+    this.props.fetchBindings(appName);
+    this.wsBindings = DataService.watchBindableServices(appName, () => {
+      this.props.fetchBindings(appName);
+    });
+
+    this.props.fetchServices();
+    this.wsServices = DataService.watchServices(this.props.fetchServices);
   }
   componentWillUnmount() {
     this.wsApps && this.wsApps.close();
     this.wsBuildConfigs && this.wsBuildConfigs.close();
     this.wsBuilds && this.wsBuilds.close();
+    this.wsBindings && this.wsBindings.close();
+    this.wsServices && this.wsServices.close();
   }
 
   getMobileApp() {
@@ -211,7 +223,9 @@ function mapStateToProps(state) {
 const mapDispatchToProps = {
   fetchApp,
   fetchBuildConfigs,
-  fetchBuilds
+  fetchBuilds,
+  fetchBindings,
+  fetchServices
 };
 
 export default connect(

--- a/ui/src/containers/Client.test.js
+++ b/ui/src/containers/Client.test.js
@@ -10,6 +10,8 @@ describe('Client', () => {
     const mockFetchApp = jest.fn();
     const mockFetchBuilds = jest.fn();
     const mockFetchBuildConfigs = jest.fn();
+    const mockFetchBindings = jest.fn();
+    const mockFetchServices = jest.fn();
 
     const props = {
       location: { hash: '' },
@@ -18,6 +20,8 @@ describe('Client', () => {
       buildTabEnabled: true,
       fetchBuildConfigs: mockFetchBuildConfigs,
       fetchBuilds: mockFetchBuilds,
+      fetchBindings: mockFetchBindings,
+      fetchServices: mockFetchServices,
       apps: { items: [{ metadata: { name: 'testapp' }, spec: { name: 'testapp' } }] },
       buildConfigs: { items: [] }
     };
@@ -26,6 +30,8 @@ describe('Client', () => {
     expect(mockFetchApp).toBeCalled();
     expect(mockFetchBuilds).toBeCalled();
     expect(mockFetchBuildConfigs).toBeCalled();
+    expect(mockFetchBindings).toBeCalled();
+    expect(mockFetchServices).toBeCalled();
     expect(wrapper.find(TabContainer).prop('activeKey')).toEqual(TAB_CONFIGURATION.key);
     expect(wrapper.find(NavItem)).toHaveLength(3);
   });
@@ -34,6 +40,8 @@ describe('Client', () => {
     const mockFetchApp = jest.fn();
     const mockFetchBuilds = jest.fn();
     const mockFetchBuildConfigs = jest.fn();
+    const mockFetchBindings = jest.fn();
+    const mockFetchServices = jest.fn();
 
     const props = {
       location: { hash: '' },
@@ -42,6 +50,8 @@ describe('Client', () => {
       buildTabEnabled: false,
       fetchBuildConfigs: mockFetchBuildConfigs,
       fetchBuilds: mockFetchBuilds,
+      fetchBindings: mockFetchBindings,
+      fetchServices: mockFetchServices,
       apps: { items: [{ metadata: { name: 'testapp' }, spec: { name: 'testapp' } }] },
       buildConfigs: { items: [] }
     };
@@ -50,6 +60,8 @@ describe('Client', () => {
     expect(mockFetchApp).toBeCalled();
     expect(mockFetchBuilds).not.toBeCalled();
     expect(mockFetchBuildConfigs).not.toBeCalled();
+    expect(mockFetchBindings).toBeCalled();
+    expect(mockFetchServices).toBeCalled();
     expect(wrapper.find(NavItem)).toHaveLength(2);
   });
 
@@ -57,6 +69,8 @@ describe('Client', () => {
     const mockFetchApp = jest.fn();
     const mockFetchBuilds = jest.fn();
     const mockFetchBuildConfigs = jest.fn();
+    const mockFetchBindings = jest.fn();
+    const mockFetchServices = jest.fn();
 
     const props = {
       location: { hash: `#${TAB_MOBILE_SERVICES.hash}` },
@@ -65,6 +79,8 @@ describe('Client', () => {
       buildTabEnabled: true,
       fetchBuildConfigs: mockFetchBuildConfigs,
       fetchBuilds: mockFetchBuilds,
+      fetchBindings: mockFetchBindings,
+      fetchServices: mockFetchServices,
       apps: { items: [{ metadata: { name: 'testapp' }, spec: { name: 'testapp' } }] },
       buildConfigs: { items: [] }
     };
@@ -73,6 +89,8 @@ describe('Client', () => {
     expect(mockFetchApp).toBeCalled();
     expect(mockFetchBuilds).toBeCalled();
     expect(mockFetchBuildConfigs).toBeCalled();
+    expect(mockFetchBindings).toBeCalled();
+    expect(mockFetchServices).toBeCalled();
     expect(wrapper.find(TabContainer).prop('activeKey')).toEqual(TAB_MOBILE_SERVICES.key);
     expect(wrapper.find(NavItem)).toHaveLength(3);
   });

--- a/ui/src/containers/Overview.js
+++ b/ui/src/containers/Overview.js
@@ -3,17 +3,14 @@ import { connect } from 'react-redux';
 
 import MobileClientCardView from '../components/overview/MobileClientCardView';
 import { fetchApps } from '../actions/apps';
-import { fetchServices } from '../actions/services';
 import { fetchBuilds } from '../actions/builds';
 import DataService from '../DataService';
 
 export class Overview extends Component {
   componentDidMount() {
     this.props.fetchApps();
-    this.props.fetchServices();
 
     this.wsApps = DataService.watchApps(this.props.fetchApps);
-    this.wsServices = DataService.watchServices(this.props.fetchServices);
 
     if (this.props.buildTabEnabled) {
       this.props.fetchBuilds();
@@ -22,11 +19,8 @@ export class Overview extends Component {
   }
 
   componentWillUnmount() {
-    this.wsApps.close();
-    this.wsServices.close();
-    if (this.wsBuilds) {
-      this.wsBuilds.close();
-    }
+    this.wsApps && this.wsApps.close();
+    this.wsBuilds && this.wsBuilds.close();
   }
 
   render() {
@@ -54,7 +48,6 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   fetchApps,
-  fetchServices,
   fetchBuilds
 };
 

--- a/ui/src/containers/Overview.test.js
+++ b/ui/src/containers/Overview.test.js
@@ -9,12 +9,10 @@ jest.mock('../DataService');
 describe('Overview', () => {
   it('test render', () => {
     const mockFetchApps = jest.fn();
-    const mockFetchServices = jest.fn();
     const mockFetchBuilds = jest.fn();
 
     const props = {
       fetchApps: mockFetchApps,
-      fetchServices: mockFetchServices,
       fetchBuilds: mockFetchBuilds,
       buildTabEnabled: true,
       apps: { items: [] },
@@ -24,10 +22,8 @@ describe('Overview', () => {
 
     const wrapper = shallow(<Overview {...props} />);
     expect(mockFetchApps).toBeCalled();
-    expect(mockFetchServices).toBeCalled();
     expect(mockFetchBuilds).toBeCalled();
     expect(DataService.watchApps).toBeCalled();
-    expect(DataService.watchServices).toBeCalled();
     expect(wrapper.find('MobileClientCardView')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8149

## What

- watch for bindings in `Client` component (higher in hierarchy) rather than in `MobileServiceView`
- watch also for services in `Client`
- only show spinner in `MobileServiceView` for first fetch (not for every update)
- don't watch for services in Overview page

## Verification Steps - `watch for services`

1. Create app in MDC and open it
2. Provision a mobile service in OpenShift
3. Open Services tab in MDC
4. When the service is provisioned it should show up

## Verification Steps - `errors in console when app is deleted`

1. Create app in MDC and bind it with a service
2. Delete the app
3. There should be no error in browser console
