### PR TITLE
Better error messages

### DIFF
--- a/pkg/web/buildConfigsHandler.go
+++ b/pkg/web/buildConfigsHandler.go
@@ -203,27 +203,27 @@ func (mbch *MobileBuildConfigsHandler) Create(c echo.Context) error {
 	reqData := new(BuildConfigCreateRequest)
 	if err := c.Bind(reqData); err != nil {
 		c.Logger().Errorf("error creating build config: %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 	if err := c.Validate(reqData); err != nil {
 		c.Logger().Errorf("error creating build config: %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 	config, secrets, err := newBuildConfigObject(*reqData, mbch.namespace)
 	if err != nil {
 		c.Logger().Errorf("error creating build config: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	config, err = mbch.buildConfigsCRUDL.Create(config)
 	if err != nil {
 		c.Logger().Errorf("error creating build config: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	for _, element := range secrets {
 		_, err := mbch.secretsCRUDL.Create(mbch.namespace, &element)
 		if err != nil {
 			c.Logger().Errorf("error creating build config: %v", err)
-			return c.String(http.StatusInternalServerError, err.Error())
+			return c.String(http.StatusInternalServerError, getErrorMessage(err))
 		}
 	}
 	return c.JSON(http.StatusOK, config)
@@ -234,7 +234,7 @@ func (mbch *MobileBuildConfigsHandler) Delete(c echo.Context) error {
 	err := mbch.buildConfigsCRUDL.DeleteByName(name)
 	if err != nil {
 		c.Logger().Errorf("error deleting build config: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -243,7 +243,7 @@ func (mbch *MobileBuildConfigsHandler) List(c echo.Context) error {
 	buildConfigs, err := mbch.buildConfigsCRUDL.List()
 	if err != nil {
 		c.Logger().Errorf("error listing build configs: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, buildConfigs)
 }
@@ -253,7 +253,7 @@ func (mbch *MobileBuildConfigsHandler) Instantiate(c echo.Context) error {
 	build, err := mbch.buildConfigsCRUDL.Instantiate(name)
 	if err != nil {
 		c.Logger().Errorf("error instantiating build: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, build)
 }
@@ -264,7 +264,7 @@ func (mbch *MobileBuildConfigsHandler) Watch(c echo.Context) error {
 	err := ServeWS(c, getWatchInterface)
 	if err != nil {
 		c.Logger().Errorf("error watching build configs: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return nil
 }

--- a/pkg/web/buildsHandler.go
+++ b/pkg/web/buildsHandler.go
@@ -23,7 +23,7 @@ func (mbh *MobileBuildsHandler) List(c echo.Context) error {
 	builds, err := mbh.buildsCRUDL.List()
 	if err != nil {
 		c.Logger().Errorf("error listing builds: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, builds)
 }
@@ -34,7 +34,7 @@ func (mbh *MobileBuildsHandler) Watch(c echo.Context) error {
 	err := ServeWS(c, getWatchInterface)
 	if err != nil {
 		c.Logger().Errorf("error watching builds: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func (mbh *MobileBuildsHandler) GenerateDownloadURL(c echo.Context) error {
 	err := mbh.buildsCRUDL.GenerateDownloadURL(name)
 	if err != nil {
 		c.Logger().Errorf("error generating download url %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.NoContent(http.StatusOK)
 }

--- a/pkg/web/deleteMobileClientHandler.go
+++ b/pkg/web/deleteMobileClientHandler.go
@@ -23,13 +23,13 @@ func (h *DeleteMobileClientHandler) Delete(c echo.Context) error {
 	mobileClient, err := h.mobileClientRepo.ReadByName(name)
 	if err != nil {
 		c.Logger().Errorf("can not read app with name %s due to error %v", name, err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 
 	err = h.appDeleter.Delete(mobileClient)
 	if err != nil {
 		c.Logger().Errorf("error deleting mobile app: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.NoContent(http.StatusOK)
 }

--- a/pkg/web/messages.go
+++ b/pkg/web/messages.go
@@ -1,0 +1,53 @@
+package web
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func statusToString(status *errors.StatusError) string {
+	switch reason := status.ErrStatus.Reason; reason {
+	case metav1.StatusReasonAlreadyExists:
+		return "Already Exists"
+	case metav1.StatusReasonBadRequest:
+		return "Bad Request"
+	case metav1.StatusReasonInternalError:
+		return "Internal Error"
+	case metav1.StatusReasonMethodNotAllowed:
+		return "Method Not Allowed"
+	case metav1.StatusReasonNotAcceptable:
+		return "Not Acceptable"
+	case metav1.StatusReasonNotFound:
+		return "Not Found"
+	case metav1.StatusReasonServerTimeout:
+		return "Server Timeout"
+	case metav1.StatusReasonServiceUnavailable:
+		return "Service Unavailable"
+	case metav1.StatusReasonTooManyRequests:
+		return "Too Many Requests"
+	case metav1.StatusReasonUnknown:
+		return "Unknown"
+	case metav1.StatusReasonUnsupportedMediaType:
+		return "Unsupported Media Type"
+	default:
+		return string(reason)
+	}
+}
+
+// Tries to return the error code for the given error. If that is not possible, Error() is returned.
+func getErrorMessage(e error) string {
+	switch t := e.(type) {
+	case *errors.StatusError:
+		switch reason := errors.ReasonForError(e); reason {
+		case metav1.StatusReasonAlreadyExists:
+			return fmt.Sprintf("Item identified by '%s' already exists", t.ErrStatus.Details.Name)
+		case metav1.StatusReasonNotFound:
+			return fmt.Sprintf("Can't find item identified by '%s'", t.ErrStatus.Details.Name)
+		default:
+			return fmt.Sprintf("An error has occurred performing the requested operation: %s", statusToString(t))
+		}
+	default:
+		return e.Error()
+	}
+}

--- a/pkg/web/messages.go
+++ b/pkg/web/messages.go
@@ -41,9 +41,17 @@ func getErrorMessage(e error) string {
 	case *errors.StatusError:
 		switch reason := errors.ReasonForError(e); reason {
 		case metav1.StatusReasonAlreadyExists:
-			return fmt.Sprintf("Item identified by '%s' already exists", t.ErrStatus.Details.Name)
+			if t.ErrStatus.Details != nil {
+				return fmt.Sprintf("Item identified by '%s' already exists", t.ErrStatus.Details.Name)
+			} else {
+				return "Requested item already exists"
+			}
 		case metav1.StatusReasonNotFound:
-			return fmt.Sprintf("Can't find item identified by '%s'", t.ErrStatus.Details.Name)
+			if t.ErrStatus.Details != nil {
+				return fmt.Sprintf("Can't find item identified by '%s'", t.ErrStatus.Details.Name)
+			} else {
+				return "Can't find requested item"
+			}
 		default:
 			return fmt.Sprintf("An error has occurred performing the requested operation: %s", statusToString(t))
 		}

--- a/pkg/web/messages_test.go
+++ b/pkg/web/messages_test.go
@@ -1,0 +1,24 @@
+package web
+
+import (
+	"github.com/pkg/errors"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	"testing"
+)
+
+func TestGetErrorMessage_std(t *testing.T) {
+	err := errors.New("Test error")
+	msg := getErrorMessage(err)
+	if msg != err.Error() {
+		t.Fatalf("Received '%s' while expecting '%s'", msg, err.Error())
+	}
+}
+
+func TestGetErrorMessage_StatusError(t *testing.T) {
+	const expect = "An error has occurred performing the requested operation: Bad Request"
+	err := errors2.NewBadRequest("Test error")
+	msg := getErrorMessage(err)
+	if msg != expect {
+		t.Fatalf("Received '%s' while expecting '%s'", msg, err.Error())
+	}
+}

--- a/pkg/web/mobileClientsHandler.go
+++ b/pkg/web/mobileClientsHandler.go
@@ -2,14 +2,13 @@ package web
 
 import (
 	"encoding/json"
-	"net/http"
-
 	"github.com/aerogear/mobile-developer-console/pkg/apis/aerogear/v1alpha1"
 	"github.com/aerogear/mobile-developer-console/pkg/mobile"
 	"github.com/labstack/echo"
 	"github.com/satori/go.uuid"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
 )
 
 type MobileClientsHandler struct {
@@ -115,22 +114,22 @@ func (h *MobileClientsHandler) Create(c echo.Context) error {
 	reqData := new(MobileAppCreateRequest)
 	if err := c.Bind(reqData); err != nil {
 		c.Logger().Errorf("error creating mobile app: %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 	if err := c.Validate(reqData); err != nil {
 		c.Logger().Errorf("error creating mobile app: %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 	app := newMobileClientObject(*reqData, h.namespace)
 	err := h.mobileClientRepo.Create(app)
 	if err != nil {
 		c.Logger().Errorf("error creating mobile app: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	data, err := newMobileClientDataFromObject(app, h.openshiftMasterURL)
 	if err != nil {
 		c.Logger().Errorf("error creating mobile app: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, data)
 }
@@ -141,15 +140,15 @@ func (h *MobileClientsHandler) Read(c echo.Context) error {
 	if err != nil {
 		if isNotFoundError(err) {
 			c.Logger().Errorf("error reading mobile app: %v", err)
-			return c.String(http.StatusNotFound, err.Error())
+			return c.String(http.StatusNotFound, getErrorMessage(err))
 		}
 		c.Logger().Errorf("error reading mobile app: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	data, err := newMobileClientDataFromObject(app, h.openshiftMasterURL)
 	if err != nil {
 		c.Logger().Errorf("error reading mobile app: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, data)
 }
@@ -158,12 +157,12 @@ func (h *MobileClientsHandler) List(c echo.Context) error {
 	apps, err := h.mobileClientRepo.List()
 	if err != nil {
 		c.Logger().Errorf("error listing mobile apps: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	data, err := newMobileClientDataListFromObjects(apps, h.openshiftMasterURL)
 	if err != nil {
 		c.Logger().Errorf("error listing mobile apps: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, data)
 }
@@ -173,20 +172,20 @@ func (h *MobileClientsHandler) Update(c echo.Context) error {
 	reqData := new(MobileAppUpdateRequest)
 	if err := c.Bind(reqData); err != nil {
 		c.Logger().Errorf("error updating mobile app: %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 	if err := c.Validate(reqData); err != nil {
 		c.Logger().Errorf("error updating mobile app: %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 	app, err := h.mobileClientRepo.ReadByName(name)
 	if err != nil {
 		if isNotFoundError(err) {
 			c.Logger().Errorf("error updating mobile app: %v", err)
-			return c.String(http.StatusNotFound, err.Error())
+			return c.String(http.StatusNotFound, getErrorMessage(err))
 		}
 		c.Logger().Errorf("error updating mobile app: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 
 	if reqData.Name != "" {
@@ -196,12 +195,12 @@ func (h *MobileClientsHandler) Update(c echo.Context) error {
 	uerr := h.mobileClientRepo.Update(app)
 	if uerr != nil {
 		c.Logger().Errorf("error updating mobile app: %v", uerr)
-		return c.String(http.StatusInternalServerError, uerr.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(uerr))
 	}
 	data, err := newMobileClientDataFromObject(app, h.openshiftMasterURL)
 	if err != nil {
 		c.Logger().Errorf("error updating mobile app: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, data)
 }
@@ -212,7 +211,7 @@ func (h *MobileClientsHandler) Watch(c echo.Context) error {
 	err := ServeWS(c, getWatchInterface)
 	if err != nil {
 		c.Logger().Errorf("error watching mobile apps: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return nil
 }

--- a/pkg/web/serverConfigHandler.go
+++ b/pkg/web/serverConfigHandler.go
@@ -36,7 +36,7 @@ func (handler *ServerConfigHandler) Handle(c echo.Context) error {
 	err := handler.template.Execute(&writer, handler.config)
 	if err != nil {
 		c.Logger().Errorf("error server config: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.Blob(http.StatusOK, echo.MIMEApplicationJavaScript, (&writer).Bytes())
 }

--- a/pkg/web/serviceBindingsHandler.go
+++ b/pkg/web/serviceBindingsHandler.go
@@ -32,7 +32,7 @@ func (msih *BindableMobileServiceHandler) List(c echo.Context) error {
 	si, err := msih.bindableServiceCRUDL.List(mobileClient)
 	if err != nil {
 		c.Logger().Errorf("error listing service bindings %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, si)
 }
@@ -43,14 +43,14 @@ func (msih *BindableMobileServiceHandler) Watch(c echo.Context) error {
 	mobileClient, err := msih.mobileClientRepo.ReadByName(mobileClientName)
 	if err != nil {
 		c.Logger().Errorf("can not read app with name %s due to error %v", mobileClientName, err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 
 	getWatchInterface := msih.bindableServiceCRUDL.Watch(mobileClient)
 	err = ServeWS(c, getWatchInterface)
 	if err != nil {
 		c.Logger().Errorf("error watching build configs: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func (msih *BindableMobileServiceHandler) Delete(c echo.Context) error {
 	err := msih.bindableServiceCRUDL.Delete(msih.namespace, name)
 	if err != nil {
 		c.Logger().Errorf("error deleting service binding %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -69,24 +69,24 @@ func (msih *BindableMobileServiceHandler) Create(c echo.Context) error {
 	reqData := new(mobile.ServiceBindingCreateRequest)
 	if err := c.Bind(&reqData); err != nil {
 		c.Logger().Errorf("Could not bind request to ServiceBindingCreateRequest %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 
 	if err := c.Validate(reqData); err != nil {
 		c.Logger().Errorf("Binding Creation failed validation %v", err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 
 	consumerID := reqData.FormData["CLIENT_ID"].(string)
 	if consumerID == "" {
 		err := errors.New("CLIENT_ID is empty")
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 
 	mobileClient, err := msih.mobileClientRepo.ReadByName(consumerID)
 	if err != nil {
 		c.Logger().Errorf("can not read app with name %s due to error %v", consumerID, err)
-		return c.String(http.StatusBadRequest, err.Error())
+		return c.String(http.StatusBadRequest, getErrorMessage(err))
 	}
 
 	binding := msih.bindableServiceCRUDL.NewBindingObject(*reqData, mobileClient)
@@ -94,7 +94,7 @@ func (msih *BindableMobileServiceHandler) Create(c echo.Context) error {
 
 	if err != nil {
 		c.Logger().Errorf("error creating service binding %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 
 	return c.JSON(200, binding)

--- a/pkg/web/serviceInstancesHandler.go
+++ b/pkg/web/serviceInstancesHandler.go
@@ -23,7 +23,7 @@ func (msih *MobileServiceInstancesHandler) List(c echo.Context) error {
 	si, err := msih.serviceInstanceLister.List()
 	if err != nil {
 		c.Logger().Errorf("error listing service instances: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return c.JSON(http.StatusOK, si)
 }
@@ -34,7 +34,7 @@ func (msih *MobileServiceInstancesHandler) Watch(c echo.Context) error {
 	err := ServeWS(c, getWatchInterface)
 	if err != nil {
 		c.Logger().Errorf("error watching service instances: %v", err)
-		return c.String(http.StatusInternalServerError, err.Error())
+		return c.String(http.StatusInternalServerError, getErrorMessage(err))
 	}
 	return nil
 }

--- a/ui/src/containers/ErrorMessages.js
+++ b/ui/src/containers/ErrorMessages.js
@@ -15,22 +15,12 @@ export class ErrorMessages extends Component {
     this.unlisten();
   }
 
-  // AlreadyExists
-  getErrorMessage(errorCode) {
-    switch (errorCode) {
-      case 'AlreadyExists':
-        return 'stoca';
-      default:
-        return errorCode;
-    }
-  }
-
   render() {
     const { errors, dismissError } = this.props;
     wsError.message && errors.push({ error: { message: wsError.message } });
     return (
       <ToastNotificationList>
-        {[...new Set(errors.map(error => this.getErrorMessage(error.error.message)))].map((error, index) => (
+        {[...new Set(errors.map(error => error.error.message))].map((error, index) => (
           <ToastNotification key={index} onDismiss={() => dismissError(error)}>
             <span>{error}</span>
           </ToastNotification>

--- a/ui/src/containers/ErrorMessages.js
+++ b/ui/src/containers/ErrorMessages.js
@@ -15,12 +15,22 @@ export class ErrorMessages extends Component {
     this.unlisten();
   }
 
+  // AlreadyExists
+  getErrorMessage(errorCode) {
+    switch (errorCode) {
+      case 'AlreadyExists':
+        return 'stoca';
+      default:
+        return errorCode;
+    }
+  }
+
   render() {
     const { errors, dismissError } = this.props;
     wsError.message && errors.push({ error: { message: wsError.message } });
     return (
       <ToastNotificationList>
-        {[...new Set(errors.map(error => error.error.message))].map((error, index) => (
+        {[...new Set(errors.map(error => this.getErrorMessage(error.error.message)))].map((error, index) => (
           <ToastNotification key={index} onDismiss={() => dismissError(error)}>
             <span>{error}</span>
           </ToastNotification>


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8143

## What
Error messages were directly reported from Kubernetes to the user make the latter receive messages like `mobileclients.mobile.k8s.io "appname" already exists"`

With this PR, the error becomes: `Item identified by 'appname' already exists`

## Verification Steps
 
1. Open the mobile developer console
2. try creating one app
3. try creating a new app with the same name as before
4. Check that the error is less _cryptic_

Try to generate other errors in other situation to verify that all the messages has been replaced.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

![screenshot 2018-12-03 at 17 39 13](https://user-images.githubusercontent.com/1125019/49387582-780f0880-f722-11e8-958c-1b52a7e9f37f.png)
