### PR TITLE
Fix: create mobile app Enter key forbidden

### DIFF
--- a/ui/src/components/create_client/EditMobileClientBaseClass.js
+++ b/ui/src/components/create_client/EditMobileClientBaseClass.js
@@ -49,7 +49,12 @@ class EditMobileClientBaseClass extends Component {
         formControl: ({ validationState, ...props }) => <Form.FormControl type="text" {...props} autoFocus />,
         validationState: this._validate(CREATE_CLIENT_NAME),
         autoComplete: 'off',
-        onChange: e => this.props.setFieldValue(CREATE_CLIENT_NAME, e.target.value)
+        onChange: e => this.props.setFieldValue(CREATE_CLIENT_NAME, e.target.value),
+        onKeyPress: event => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+          }
+        }
       }
     ];
   }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8208

## What
Blocking Enter key in create app dialog.

## Why
When you pressed it, it would refresh the page without creating the app.

## How
Blocking keypress event in the app name field.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Go to overview screen
2. Press `Create Mobile App` 
3. Fill in name
4. Press Enter, it's expected for the dialog not to close.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task