### PR TITLE
 🐛 fix errors when try to create new build config

### DIFF
--- a/pkg/web/buildConfigsHandler.go
+++ b/pkg/web/buildConfigsHandler.go
@@ -169,7 +169,6 @@ func newBuildConfigObject(data BuildConfigCreateRequest, namespace string) (*mob
 				"mobile-client-build":          "true",
 				"mobile-client-build-platform": data.Build.Platform,
 				mobile.BUILD_CONFIG_LABEL_NAME: data.ClientID,
-				"mobile-client-type":           data.ClientType,
 			},
 		},
 		Spec: buildV1.BuildConfigSpec{

--- a/pkg/web/types.go
+++ b/pkg/web/types.go
@@ -94,7 +94,6 @@ type BuildConfig struct {
 type BuildConfigCreateRequest struct {
 	Name                 string          `json:"name" validate:"required"`
 	ClientID             string          `json:"clientId" validate:"required"`
-	ClientType           string          `json:"clientType" validate:"required,oneof=android iOS cordova xamarin"`
 	Source               SourceConfig    `json:"source" validate:"required"`
 	Build                BuildConfig     `json:"build" validate:"required"`
 	EnvironmentVariables []corev1.EnvVar `json:"envVars"`

--- a/ui/src/containers/Client.js
+++ b/ui/src/containers/Client.js
@@ -138,7 +138,7 @@ export class Client extends Component {
                 <MenuItem onClick={() => this.setState({ showBuildConfigDialog: true })}>New build config</MenuItem>
                 <BuildConfigDialog
                   update={false}
-                  clientInfo={{ clientId: '' }}
+                  clientInfo={{ clientId: mobileApp.getName() }}
                   show={showBuildConfigDialog}
                   onShowStateChanged={isShown => this.setState({ showBuildConfigDialog: isShown })}
                 />
@@ -155,7 +155,7 @@ export class Client extends Component {
 
   render() {
     const mobileApp = this.getMobileApp();
-    const clientInfo = { clientId: '' };
+    const clientInfo = { clientId: mobileApp.getName() };
     const { selectedTab } = this.state;
     const appName = this.props.match.params.id;
     return mobileApp ? (


### PR DESCRIPTION
## Motivation

Fix the errors when try to create new build configs.

## Verifications:

1. Enable build tab if it's not showing (you can change it via env vars)
2. Try create new build configs via the button or from the dropdown. They all should work.
 

