### PR TITLE
🐛 fix: verify docker is running before starting a cluster

### DIFF
--- a/scripts/minishift.sh
+++ b/scripts/minishift.sh
@@ -2,6 +2,18 @@
 
 cd "$(dirname "$0")"
 
+# If docker isn't running we'll run into issues later using "yq"
+# Checking the version is a simple way to determine if the daemon is running
+docker version &> /dev/null
+
+docker_status=$?
+
+if [ $docker_status -ne 0 ]
+then
+    echo "Error: verify docker is installed and active";
+    exit 1
+fi
+
 minishift delete -f
 
 MINISHIFT_ENABLE_EXPERIMENTAL=y minishift start --openshift-version v3.11.0 \


### PR DESCRIPTION
## Motivation
Improve ~user~ developer experience.

## What
Added a check to verify docker is running before starting minishift and performing other install steps.

## Why
If the docker daemon is not active on the machine the `minishift.sh` script will continue running and create a cluster, but ultimately the mobile developer console will not be available.

## How
Added a simple check to verify the docker daemon is running before doing anything else.

## Verification Steps
The following is an example tested on macOS
 
1. Kill the docker daemon
2. Run `./scripts/minishift.sh`
3. Note errors such as `Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`
4. Note that the script still completes and reports success despite errors

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

I can move the check elsewhere, but it makes sense to run it ASAP. 
 

