### PR TITLE
Fix for Input text fields gets emptied when other binding is in progress

### DIFF
--- a/ui/src/components/mobileservices/BoundServiceRow.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.js
@@ -3,7 +3,6 @@ import { ListViewItem, Row, Col, DropdownKebab } from 'patternfly-react';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
 import DeleteItemButton from '../../containers/DeleteItemButton';
-import BindingPanel from './BindingPanel';
 import BindingStatus from './BindingStatus';
 import BindButton from './BindButton';
 
@@ -18,10 +17,6 @@ function configurationView(configuration) {
 class BoundServiceRow extends Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      showModal: false
-    };
 
     this.renderServiceBadge = this.renderServiceBadge.bind(this);
     this.renderServiceDetails = this.renderServiceDetails.bind(this);
@@ -128,7 +123,7 @@ class BoundServiceRow extends Component {
       }
     }
 
-    return <BindButton service={this.props.service} onClick={() => this.setState({ showModal: true })} />;
+    return <BindButton service={this.props.service} onClick={this.props.onCreateBinding} />;
   }
 
   renderDeleteBindingDropdowns() {
@@ -149,30 +144,19 @@ class BoundServiceRow extends Component {
 
   render() {
     return (
-      <React.Fragment>
-        <ListViewItem
-          additionalInfo={[this.renderServiceBadge(), this.renderBindingStatus()]}
-          className="boundService"
-          actions={
-            <div>
-              {this.renderBindingButtons()}
-              {this.renderDeleteBindingDropdowns()}
-            </div>
-          }
-          hideCloseIcon
-        >
-          {this.renderServiceDetails()}
-        </ListViewItem>
-        {this.props.service.isUPSService() && (
-          <BindingPanel
-            service={this.props.service}
-            showModal={this.state.showModal}
-            close={() => {
-              this.setState({ showModal: false });
-            }}
-          />
-        )}
-      </React.Fragment>
+      <ListViewItem
+        additionalInfo={[this.renderServiceBadge(), this.renderBindingStatus()]}
+        className="boundService"
+        actions={
+          <div>
+            {this.renderBindingButtons()}
+            {this.renderDeleteBindingDropdowns()}
+          </div>
+        }
+        hideCloseIcon
+      >
+        {this.renderServiceDetails()}
+      </ListViewItem>
     );
   }
 }

--- a/ui/src/components/mobileservices/BoundServiceRow.test.js
+++ b/ui/src/components/mobileservices/BoundServiceRow.test.js
@@ -128,8 +128,6 @@ describe('BoundServiceRow - UPS - 1 binding', () => {
     expect(wrapper.find('BindButton')).toHaveLength(1);
     expect(wrapper.find('BindingStatus')).toHaveLength(1);
     expect(wrapper.find('DeleteItemButton')).toHaveLength(1);
-    expect(bindingSchema.properties.CLIENT_TYPE.default).toEqual('IOS');
-    expect(bindingSchema.properties.CLIENT_TYPE.enum).toEqual(['IOS']);
   });
 });
 

--- a/ui/src/components/mobileservices/MobileServiceView.js
+++ b/ui/src/components/mobileservices/MobileServiceView.js
@@ -7,10 +7,16 @@ import UnboundServiceRow from './UnboundServiceRow';
 import './MobileServiceView.css';
 import DataService from '../../DataService';
 import { fetchBindings } from '../../actions/serviceBinding';
+import BindingPanel from './BindingPanel';
 
 class MobileServiceView extends Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      bindingPanelService: null
+    };
+
     this.boundServiceRows = this.boundServiceRows.bind(this);
     this.unboundServiceRows = this.unboundServiceRows.bind(this);
     this.addDefaultBindingProperty = this.addDefaultBindingProperty.bind(this);
@@ -34,7 +40,13 @@ class MobileServiceView extends Component {
         {this.props.boundServices && this.props.boundServices.length > 0 ? (
           this.props.boundServices.map(service => {
             this.addDefaultBindingProperty(service);
-            return <BoundServiceRow key={service.getId()} service={service} />;
+            return (
+              <BoundServiceRow
+                key={service.getId()}
+                service={service}
+                onCreateBinding={() => this.showBindingPanel(service)}
+              />
+            );
           })
         ) : (
           <EmptyState>There are no bound services.</EmptyState>
@@ -50,7 +62,13 @@ class MobileServiceView extends Component {
         {this.props.unboundServices && this.props.unboundServices.length > 0 ? (
           this.props.unboundServices.map(service => {
             this.addDefaultBindingProperty(service);
-            return <UnboundServiceRow key={service.getId()} service={service} />;
+            return (
+              <UnboundServiceRow
+                key={service.getId()}
+                service={service}
+                onCreateBinding={() => this.showBindingPanel(service)}
+              />
+            );
           })
         ) : (
           <EmptyState>There are no unbound services.</EmptyState>
@@ -68,6 +86,18 @@ class MobileServiceView extends Component {
     service.setBindingSchemaDefaultValues('CLIENT_ID', this.props.appName);
   }
 
+  showBindingPanel = service => {
+    this.setState({
+      bindingPanelService: service
+    });
+  };
+
+  hideBindingPanel = () => {
+    this.setState({
+      bindingPanelService: null
+    });
+  };
+
   render() {
     const { isReading = true, boundServices, unboundServices } = this.props;
     return (
@@ -79,6 +109,9 @@ class MobileServiceView extends Component {
           {this.boundServiceRows()}
           {this.unboundServiceRows()}
         </Spinner>
+        {this.state.bindingPanelService && (
+          <BindingPanel service={this.state.bindingPanelService} showModal close={this.hideBindingPanel} />
+        )}
       </div>
     );
   }

--- a/ui/src/components/mobileservices/UnboundServiceRow.js
+++ b/ui/src/components/mobileservices/UnboundServiceRow.js
@@ -2,17 +2,12 @@ import React, { Component } from 'react';
 import { ListViewItem, Col } from 'patternfly-react';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
-import BindingPanel from './BindingPanel';
 import BindingStatus from './BindingStatus';
 import BindButton from './BindButton';
 
 class UnboundServiceRow extends Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      showModal: false
-    };
 
     this.renderServiceBadge = this.renderServiceBadge.bind(this);
     this.renderBindingStatus = this.renderBindingStatus.bind(this);
@@ -51,27 +46,18 @@ class UnboundServiceRow extends Component {
   renderBindingButtons() {
     return (
       <div>
-        <BindButton service={this.props.service} onClick={() => this.setState({ showModal: true })} />
+        <BindButton service={this.props.service} onClick={this.props.onCreateBinding} />
       </div>
     );
   }
 
   render() {
     return (
-      <React.Fragment>
-        <ListViewItem
-          additionalInfo={[this.renderServiceBadge(), this.renderBindingStatus()]}
-          className="unboundService"
-          actions={this.renderBindingButtons()}
-        />
-        <BindingPanel
-          service={this.props.service}
-          showModal={this.state.showModal}
-          close={() => {
-            this.setState({ showModal: false });
-          }}
-        />
-      </React.Fragment>
+      <ListViewItem
+        additionalInfo={[this.renderServiceBadge(), this.renderBindingStatus()]}
+        className="unboundService"
+        actions={this.renderBindingButtons()}
+      />
     );
   }
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8248

## What
`BindingPanel` moved from service rows to `ServiceView`.

## Why
Seems that BindingPanel gets rerendered, when there is an update from websocket.

