### PR TITLE
AEROGEAR-8239

### DIFF
--- a/ui/src/components/mobileservices/BindingPanel.js
+++ b/ui/src/components/mobileservices/BindingPanel.js
@@ -1,3 +1,4 @@
+import { partition, find } from 'lodash-es';
 import React, { Component } from 'react';
 import { Wizard } from 'patternfly-react';
 import { connect } from 'react-redux';
@@ -20,32 +21,10 @@ export class BindingPanel extends Component {
     this.onBackButtonClick = this.onBackButtonClick.bind(this);
     this.renderPropertiesSchema = this.renderPropertiesSchema.bind(this);
     this.validate = this.validate.bind(this);
-
     const serviceName = this.props.service.getName();
     const schema = this.props.service.getBindingSchema();
     const form = this.props.service.getFormDefinition();
     const { service } = this.props;
-
-    if (this.props.service.isUPSService()) {
-      const hasUPSAndroidAnnotation = this.hasUPSAndroidAnnotation();
-      const hasUPSIOSAnnotation = this.hasUPSIOSAnnotation();
-
-      if (hasUPSAndroidAnnotation && !hasUPSIOSAnnotation) {
-        // UPS, there's already an Android variant
-        if (schema.properties.CLIENT_TYPE) {
-          schema.properties.CLIENT_TYPE.default = 'IOS';
-          schema.properties.CLIENT_TYPE.enum = ['IOS'];
-        }
-      } else if (!hasUPSAndroidAnnotation && hasUPSIOSAnnotation) {
-        // UPS, there's already an IOS variant
-        if (schema.properties.CLIENT_TYPE) {
-          schema.properties.CLIENT_TYPE.default = 'Android';
-          schema.properties.CLIENT_TYPE.enum = ['Android'];
-        }
-      }
-      // we don't care if there are variants for both platforms.
-      // this binding panel shouldn't be shown anyway
-    }
 
     this.state = {
       serviceName,
@@ -55,6 +34,28 @@ export class BindingPanel extends Component {
       service,
       activeStepIndex: 0
     };
+  }
+
+  reinitState() {
+    const serviceName = this.props.service.getName();
+    const schema = this.props.service.getBindingSchema();
+    const form = this.props.service.getFormDefinition();
+    const { service } = this.props;
+
+    this.setState({
+      serviceName,
+      schema,
+      form,
+      loading: false,
+      service,
+      activeStepIndex: 0
+    });
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextProps.showModal === false) {
+      this.reinitState();
+    }
   }
 
   onNextButtonClick() {
@@ -77,37 +78,27 @@ export class BindingPanel extends Component {
   }
 
   show() {
+    this.reinitState();
     this.stepChanged(0);
     this.open();
   }
 
-  hasUPSAndroidAnnotation() {
-    return this.hasUPSPlatformAnnotation('android');
+  hasUPSIOSBoundService() {
+    return this.hasUPSIOSBoundServiceForPlatform('ios');
   }
 
-  hasUPSIOSAnnotation() {
-    return this.hasUPSPlatformAnnotation('ios');
+  hasUPSAndroidBoundService() {
+    return this.hasUPSIOSBoundServiceForPlatform('android');
   }
 
-  hasUPSPlatformAnnotation(platform) {
-    // there won't be any variant annotations if there is no binding yet
-    if (!this.props.service.isBound()) {
-      return false;
-    }
-
-    const configExtItems = this.props.service.getConfigurationExtAsJSON();
-    if (!configExtItems || !configExtItems.length) {
-      return false;
-    }
-
-    for (const configExtItem of configExtItems) {
-      for (const variantInfo of configExtItem) {
-        if (variantInfo.type === platform) {
-          return true;
-        }
-      }
-    }
-    return false;
+  hasUPSIOSBoundServiceForPlatform(platform) {
+    return find(
+      this.getBoundServices(),
+      service =>
+        service.isUPSService() &&
+        service.serviceBindings &&
+        find(service.serviceBindings, serviceBinding => serviceBinding.getPlatform() === platform)
+    );
   }
 
   renderPropertiesSchema() {
@@ -205,7 +196,42 @@ export class BindingPanel extends Component {
     return errors;
   };
 
+  filterPlatforms() {
+    if (this.props.service.isUPSService()) {
+      const hasIOS = this.hasUPSIOSBoundService();
+      const hasAndroid = this.hasUPSAndroidBoundService();
+      const { schema } = this.state;
+      if (!hasAndroid && !hasIOS) {
+        if (schema.properties.CLIENT_TYPE) {
+          schema.properties.CLIENT_TYPE.default = 'Android';
+          schema.properties.CLIENT_TYPE.enum = ['Android', 'IOS'];
+        }
+      } else if (hasAndroid && !hasIOS) {
+        // UPS, there's already an Android variant
+        if (schema.properties.CLIENT_TYPE) {
+          schema.properties.CLIENT_TYPE.default = 'IOS';
+          schema.properties.CLIENT_TYPE.enum = ['IOS'];
+        }
+      } else if (!hasAndroid && hasIOS) {
+        // UPS, there's already an IOS variant
+        if (schema.properties.CLIENT_TYPE) {
+          schema.properties.CLIENT_TYPE.default = 'Android';
+          schema.properties.CLIENT_TYPE.enum = ['Android'];
+        }
+      } else if (hasAndroid && hasIOS) {
+        // UPS, there's already an IOS variant
+        if (schema.properties.CLIENT_TYPE) {
+          schema.properties.CLIENT_TYPE.default = '';
+          schema.properties.CLIENT_TYPE.enum = [];
+        }
+      }
+      // we don't care if there are variants for both platforms.
+      // this binding panel shouldn't be shown anyway
+    }
+  }
+
   render() {
+    this.filterPlatforms();
     return (
       <Wizard.Pattern
         onHide={this.props.close}
@@ -224,13 +250,29 @@ export class BindingPanel extends Component {
       />
     );
   }
+
+  getBoundServices() {
+    const filteredServices = partition(this.props.serviceBindings.services, service => service.isBound());
+    return filteredServices[0];
+  }
+
+  getUnboundServices() {
+    const filteredServices = partition(this.props.serviceBindings.services, service => service.isBound());
+    return filteredServices[1];
+  }
 }
 
 const mapDispatchToProps = {
   createBinding
 };
 
+function mapStateToProps(state) {
+  return {
+    serviceBindings: state.serviceBindings
+  };
+}
+
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(BindingPanel);

--- a/ui/src/components/mobileservices/BindingPanel.js
+++ b/ui/src/components/mobileservices/BindingPanel.js
@@ -36,28 +36,6 @@ export class BindingPanel extends Component {
     };
   }
 
-  reinitState() {
-    const serviceName = this.props.service.getName();
-    const schema = this.props.service.getBindingSchema();
-    const form = this.props.service.getFormDefinition();
-    const { service } = this.props;
-
-    this.setState({
-      serviceName,
-      schema,
-      form,
-      loading: false,
-      service,
-      activeStepIndex: 0
-    });
-  }
-
-  componentWillUpdate(nextProps, nextState) {
-    if (nextProps.showModal === false) {
-      this.reinitState();
-    }
-  }
-
   onNextButtonClick() {
     const { activeStepIndex } = this.state;
     if (activeStepIndex === 1) {
@@ -78,20 +56,19 @@ export class BindingPanel extends Component {
   }
 
   show() {
-    this.reinitState();
     this.stepChanged(0);
     this.open();
   }
 
   hasUPSIOSBoundService() {
-    return this.hasUPSIOSBoundServiceForPlatform('ios');
+    return this.hasUPSBoundServiceForPlatform('ios');
   }
 
   hasUPSAndroidBoundService() {
-    return this.hasUPSIOSBoundServiceForPlatform('android');
+    return this.hasUPSBoundServiceForPlatform('android');
   }
 
-  hasUPSIOSBoundServiceForPlatform(platform) {
+  hasUPSBoundServiceForPlatform(platform) {
     return find(
       this.getBoundServices(),
       service =>


### PR DESCRIPTION
## Motivation
JIRA:

- https://issues.jboss.org/browse/AEROGEAR-8239
- https://issues.jboss.org/browse/AEROGEAR-8247

# What

- Fixed the wizard so that wizard state is always reset to initial state when opening
- Fixed platform filtering in filling the selectbox
- Fixed method used to list the bound/unbound services to comply with the rest of the MDC

# Verification steps

1. Create a new app
2. Bind UPS for iOS to the app
3. Try binding another UPS instance: only android must be available
4. After binding android too, try binding another service: the listbox should be empty (the bind button should disappear. Issue : [AEROGEAR-8273](https://issues.jboss.org/browse/AEROGEAR-8273)
5. Delete the iOS or the Android binding: only the binding for the other platform should be available
6. Delete the last UPS binding: binding for both platforms should be available again