### PR TITLE
Fix integration tests - remove all apps before starting the test

### DIFF
--- a/integration_tests/mobile_clients/index.js
+++ b/integration_tests/mobile_clients/index.js
@@ -5,6 +5,14 @@ const template = {
   name: "integration-test-client"
 }
 
+before('remove all mobile apps', async function() {
+  const res = await sendRequest('GET', 'mobileclients');
+  assert.equal(res.status, 200);
+  for (const app of res.data.items) {
+    await sendRequest('DELETE', `mobileclients/${app.metadata.name}`)
+  }
+});
+
 describe('initially', () => {
   it('should have no mobile clients present', async () => {
     const res = await sendRequest('GET', 'mobileclients')


### PR DESCRIPTION
## Motivation
This should fix issue in central ci. e2e tests do not cleanup when they finish. So if integration tests will run after that, they will fail. https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/mdc-integration-test/57/console
