### PR TITLE
Bumped aerogearcatalog version to 1.0.0-alpha2 (was 1.0.0-alpha)

### DIFF
--- a/scripts/yml/aerogearcatalog_registry.yaml
+++ b/scripts/yml/aerogearcatalog_registry.yaml
@@ -11,7 +11,7 @@ registry:
   - type: dockerhub
     name: ag-mdc
     org: aerogearcatalog
-    tag: 1.0.0-alpha
+    tag: 1.0.0-alpha2
     url: https://registry.hub.docker.com
     white_list:
     - '.*mobile-developer-console-apb$'


### PR DESCRIPTION
## Motivation

Releasing MDC 1.0.0-alpha2