### PR TITLE
Build the node-sass binary with mvn offline builds

### DIFF
--- a/ui/node_modules/.hooks/preinstall
+++ b/ui/node_modules/.hooks/preinstall
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+# This script should only execute when npm run with mvn
+if [[ ! -z ${MAVEN_PROJECTBASEDIR} && ${npm_package_name} == node-sass ]]
+then
+    echo "Running node-gyp for node-sass in preinstall"
+    ${npm_config_prefix}/node_modules/node-gyp/bin/node-gyp.js rebuild \
+                        --dist-url=${npm_config_dist_url}
+fi

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -132,6 +132,10 @@
 
         <configuration>
           <workingDirectory>./</workingDirectory>
+          <environmentVariables>
+            <SASS_BINARY_PATH>${project.basedir}/node_modules/node-sass/build/Release/binding.node</SASS_BINARY_PATH>
+            <npm_config_dist_url>${nodeDownloadRoot}</npm_config_dist_url>
+          </environmentVariables>
         </configuration>
 
         <executions>
@@ -153,7 +157,7 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <arguments>ci --cache npm-cache</arguments>
+              <arguments>install --cache npm-cache</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
By default node-sass will try to download the binding.node binary file
from GitHub, which is of course blocked when offline.

Just setting the relevant environment variable to tell it to always
compile it won't work, because then node-gyp will try to download the
Node.js headers from nodejs.org, which is of course also blocked when
offline.

Passing the dist-url for node-gyp via the `npm_config_dist_url`
environment variable won't work, because node-sass spawns node-gyp in
some way that all the environment of the npm process are not there.

Creating a `node_modules/.hooks/preinstall` script on our end is the
only way to get control over it from our level. We only really want to
do things from this script if it's being run by maven (i.e. in our
Koji instance), and for the node-sass dependency.

Also, even though we should be running `npm ci` (so that no changes
are made to the package-lock.json), we now need to run `npm install`
instead, since `npm ci` would clear the node_modules directory (and
therefore our script).

Also, we need to run the node-gyp.js from the dependency in
node_modules, rather than the one from the node distribution that we
download, because for some reason when the frontend-maven-plugin sets
up the node install, it doesn't set +x for the node-gyp scripts.