### PR TITLE
Issue AEROGEAR-8604

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ jobs:
       - run: go get -u github.com/golang/dep/cmd/dep
       - run: make build
       - run: make test_cover
-      - run: /go/bin/goveralls -coverprofile=coverage-all.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+# Disable goveralls to make build work when merging from forks
+#      - run: /go/bin/goveralls -coverprofile=coverage-all.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 
   build_ui:
     working_directory: ~/mobile-developer-console

--- a/ui/src/components/configuration/ServiceSDKDocs.js
+++ b/ui/src/components/configuration/ServiceSDKDocs.js
@@ -11,9 +11,15 @@ export const ServiceSDKDocs = ({ framework, mobileApp }) => {
         {framework.steps.map((docs, index) => (
           <ServiceSDKSetup docs={docs} key={`docs-${index}`} />
         ))}
-        {services.map(({ type }, index) =>
-          framework.services[type].steps.map(docs => <ServiceSDKSetup key={`sdk-setup-${index}`} docs={docs} />)
-        )}
+        {services.map(({ type }, index) => {
+          if (framework.services[type]) {
+            return framework.services[type].steps.map(docs => (
+              <ServiceSDKSetup key={`sdk-setup-${index}`} docs={docs} />
+            ));
+          }
+          console.error(`Bad service type found '${type}'`);
+          return null;
+        })}
       </ol>
     ) : (
       <React.Fragment />

--- a/ui/src/components/configuration/ServiceSDKDocs.test.js
+++ b/ui/src/components/configuration/ServiceSDKDocs.test.js
@@ -21,7 +21,7 @@ describe('ServiceSDKDocs', () => {
       ).toEqual(frameworkDocs.steps[i]);
     }
     services.forEach(({ type }) => {
-      for (let i = 0; i < frameworkDocs.services[type].steps.length; i++) {
+      for (let i = 0; frameworkDocs.services[type] && i < frameworkDocs.services[type].steps.length; i++) {
         expect(wrapper.find(ServiceSDKSetup).map(node => node.prop('docs'))).toContain(
           frameworkDocs.services[type].steps[i]
         );

--- a/ui/src/components/configuration/ServiceSDKInfo.js
+++ b/ui/src/components/configuration/ServiceSDKInfo.js
@@ -10,28 +10,32 @@ export const ServiceSDKInfo = ({ framework, mobileApp }) => {
     return services ? (
       <React.Fragment>
         {services.map(({ type }) => {
-          const { serviceLogoUrl, serviceName, setupText, docsLink } = framework.services[type];
-          return (
-            <Col md={6} className="service-sdk-info" key={`sdk-info-${serviceName}`}>
-              <Col md={12}>
-                <img src={serviceLogoUrl} alt="" />
-                <div className="service-name">
-                  <h4>
-                    <div>{serviceName}</div>
-                  </h4>
-                </div>
+          if (framework.services[type]) {
+            const { serviceLogoUrl, serviceName, setupText, docsLink } = framework.services[type];
+            return (
+              <Col md={6} className="service-sdk-info" key={`sdk-info-${serviceName}`}>
+                <Col md={12}>
+                  <img src={serviceLogoUrl} alt="" />
+                  <div className="service-name">
+                    <h4>
+                      <div>{serviceName}</div>
+                    </h4>
+                  </div>
+                </Col>
+                <Col md={12}>
+                  <div className="service-details" key={`sdk-details-${serviceName}`}>
+                    <h5>
+                      <a href={docsLink} target="_blank" rel="noopener noreferrer">
+                        {setupText}
+                      </a>
+                    </h5>
+                  </div>
+                </Col>
               </Col>
-              <Col md={12}>
-                <div className="service-details" key={`sdk-details-${serviceName}`}>
-                  <h5>
-                    <a href={docsLink} target="_blank" rel="noopener noreferrer">
-                      {setupText}
-                    </a>
-                  </h5>
-                </div>
-              </Col>
-            </Col>
-          );
+            );
+          }
+          console.error(`Bad service type found '${type}'`);
+          return null;
         })}
       </React.Fragment>
     ) : (

--- a/ui/src/components/configuration/ServiceSDKInfo.test.js
+++ b/ui/src/components/configuration/ServiceSDKInfo.test.js
@@ -4,6 +4,8 @@ import { MobileApp } from '../../models';
 import { appJSON, framework } from './sdk-config-docs/sdkdocs-test-data';
 import ServiceSDKInfo from './ServiceSDKInfo';
 
+const BAD_SERVICE_TYPE = 'bad-service-type';
+
 describe('ServiceSDKInfo', () => {
   it('test render', () => {
     const app = new MobileApp(appJSON);
@@ -12,11 +14,13 @@ describe('ServiceSDKInfo', () => {
     const services = app.getStatus().getServices();
     const wrapper = shallow(<ServiceSDKInfo mobileApp={app} framework={frameworkDocs} />);
     services.forEach(({ type }) => {
-      const { serviceLogoUrl, serviceName, setupText, docsLink } = frameworkDocs.services[type];
-      expect(wrapper.find('img').map(node => node.prop('src'))).toContain(serviceLogoUrl);
-      expect(wrapper.find('.service-name > h4 > div').map(node => node.text())).toContain(serviceName);
-      expect(wrapper.find('.service-details > h5 > a').map(node => node.prop('href'))).toContain(docsLink);
-      expect(wrapper.find('.service-details > h5 > a').map(node => node.text())).toContain(setupText);
+      if (type !== BAD_SERVICE_TYPE) {
+        const { serviceLogoUrl, serviceName, setupText, docsLink } = frameworkDocs.services[type];
+        expect(wrapper.find('img').map(node => node.prop('src'))).toContain(serviceLogoUrl);
+        expect(wrapper.find('.service-name > h4 > div').map(node => node.text())).toContain(serviceName);
+        expect(wrapper.find('.service-details > h5 > a').map(node => node.prop('href'))).toContain(docsLink);
+        expect(wrapper.find('.service-details > h5 > a').map(node => node.text())).toContain(setupText);
+      }
     });
   });
 });

--- a/ui/src/components/configuration/sdk-config-docs/cordova.js
+++ b/ui/src/components/configuration/sdk-config-docs/cordova.js
@@ -1,109 +1,115 @@
-const framework = docsVersion => ({
-  icon: '/img/cordova.png',
-  title: 'Cordova',
-  steps: [
-    {
-      introduction:
-        'Please note that our SDKs are delivered as npm modules. This means in order to use them, you should use a build system in your project that can load npm modules.'
-    },
-    {
-      introduction:
-        'Install the Core AeroGear module, the module manages and binds all services together on the client side.',
-      commands: [
-        'Open a terminal and navigate to the root foler of your appplication project.',
-        ['Install AeroGear Core package, from the terminal, execute:', '```npm install @aerogear/app```']
-      ]
-    },
-    {
-      introduction: 'Create the `mobile-services.json` file.',
-      commands: [
-        "Create a file called `mobile-services.json` in your project's source folder. It should be right beside the main entry file of your project.",
-        'Copy the contents from the panel on the right and paste them into this new file'
-      ]
-    },
-    {
-      introduction: 'Initialize application with services configuration.',
-      commands: [
-        [
-          'To init, load the content from `mobile-services.json` file, and pass it to init. It is recommended to have this code in the main entry file of your project.',
-          `\`\`\`js 
+const framework = docsVersion => {
+  const ret = {
+    icon: '/img/cordova.png',
+    title: 'Cordova',
+    steps: [
+      {
+        introduction:
+          'Please note that our SDKs are delivered as npm modules. This means in order to use them, you should use a build system in your project that can load npm modules.'
+      },
+      {
+        introduction:
+          'Install the Core AeroGear module, the module manages and binds all services together on the client side.',
+        commands: [
+          'Open a terminal and navigate to the root foler of your appplication project.',
+          ['Install AeroGear Core package, from the terminal, execute:', '```npm install @aerogear/app```']
+        ]
+      },
+      {
+        introduction: 'Create the `mobile-services.json` file.',
+        commands: [
+          "Create a file called `mobile-services.json` in your project's source folder. It should be right beside the main entry file of your project.",
+          'Copy the contents from the panel on the right and paste them into this new file'
+        ]
+      },
+      {
+        introduction: 'Initialize application with services configuration.',
+        commands: [
+          [
+            'To init, load the content from `mobile-services.json` file, and pass it to init. It is recommended to have this code in the main entry file of your project.',
+            `\`\`\`js 
           import { init } from "@aerogear/app";
           const appConfig = require("./mobile-services.json");
           const app = init(appConfig);`
+          ]
         ]
-      ]
-    }
-  ],
-  services: {
-    keycloak: {
-      serviceLogoUrl: '/img/keycloak.png',
-      serviceName: 'Identity Management',
-      serviceDescription: 'Identity Management - Identity and Access Management',
-      setupText: 'Identity Management SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/identity-management.html#setup`,
-      steps: [
-        {
-          introduction:
-            'Execute following commands in your project directory to install all necessary NPM packages needed for the Identity Management service:',
-          commands: [['Install the AeroGear Auth package from NPM', '```npm install @aerogear/auth```']]
-        }
-      ]
-    },
-    push: {
-      serviceLogoUrl: '/img/push.png',
-      serviceName: 'Push Notifications',
-      serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
-      setupText: 'Push SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/push-notifications.html#setup`,
-      steps: [
-        {
-          introduction:
-            'Execute following commands in your project directory to install all necessary NPM packages needed for the Push Notifications service:',
-          commands: [
-            ['Install Cordova plugin for push', '```cordova plugin add @aerogear/cordova-plugin-aerogear-push```'],
-            ['Install Unified Push Server package needed for Device registration', '```npm install @aerogear/push```']
-          ]
-        }
-      ]
-    },
-    metrics: {
-      serviceLogoUrl: '/img/metrics.png',
-      serviceName: 'Mobile Metrics',
-      serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
-      setupText: 'Mobile Metrics SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/mobile-metrics.html#setup`,
-      steps: [
-        {
-          introduction:
-            "Metrics is included in all SDK modules, if you already use a component from the AeroGear SDK in your app. You'll need only to install this Cordova plugin to enable it:",
-          commands: [
-            ['Install Metrics Cordova plugin', '```cordova plugin add @aerogear/cordova-plugin-aerogear-metrics```']
-          ]
-        }
-      ]
-    },
-    sync: {
-      serviceLogoUrl: '/img/sync.svg',
-      serviceName: 'Sync',
-      serviceDescription: 'Installs Sync service based on Voyager Server',
-      setupText: 'Sync SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/data-sync.html#setup`,
+      }
+    ],
+    services: {
+      keycloak: {
+        serviceLogoUrl: '/img/keycloak.png',
+        serviceName: 'Identity Management',
+        serviceDescription: 'Identity Management - Identity and Access Management',
+        setupText: 'Identity Management SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/identity-management.html#setup`,
+        steps: [
+          {
+            introduction:
+              'Execute following commands in your project directory to install all necessary NPM packages needed for the Identity Management service:',
+            commands: [['Install the AeroGear Auth package from NPM', '```npm install @aerogear/auth```']]
+          }
+        ]
+      },
+      push: {
+        serviceLogoUrl: '/img/push.png',
+        serviceName: 'Push Notifications',
+        serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
+        setupText: 'Push SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/push-notifications.html#setup`,
+        steps: [
+          {
+            introduction:
+              'Execute following commands in your project directory to install all necessary NPM packages needed for the Push Notifications service:',
+            commands: [
+              ['Install Cordova plugin for push', '```cordova plugin add @aerogear/cordova-plugin-aerogear-push```'],
+              ['Install Unified Push Server package needed for Device registration', '```npm install @aerogear/push```']
+            ]
+          }
+        ]
+      },
+      metrics: {
+        serviceLogoUrl: '/img/metrics.png',
+        serviceName: 'Mobile Metrics',
+        serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
+        setupText: 'Mobile Metrics SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/mobile-metrics.html#setup`,
+        steps: [
+          {
+            introduction:
+              "Metrics is included in all SDK modules, if you already use a component from the AeroGear SDK in your app. You'll need only to install this Cordova plugin to enable it:",
+            commands: [
+              ['Install Metrics Cordova plugin', '```cordova plugin add @aerogear/cordova-plugin-aerogear-metrics```']
+            ]
+          }
+        ]
+      },
+      sync: {
+        serviceLogoUrl: '/img/sync.svg',
+        serviceName: 'Sync',
+        serviceDescription: 'Installs Sync service based on Voyager Server',
+        setupText: 'Sync SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/data-sync.html#setup`,
 
-      steps: [
-        {
-          introduction:
-            'Execute following commands in your project directory to install all necessary NPM packages needed for the Sync service:',
-          commands: [
-            [
+        steps: [
+          {
+            introduction:
+              'Execute following commands in your project directory to install all necessary NPM packages needed for the Sync service:',
+            commands: [
               [
-                'Install AeroGear Sync Cordova plugin',
-                '```cordova plugin add @aerogear/cordova-plugin-aerogear-sync```'
+                [
+                  'Install AeroGear Sync Cordova plugin',
+                  '```cordova plugin add @aerogear/cordova-plugin-aerogear-sync```'
+                ]
               ]
             ]
-          ]
-        }
-      ]
+          }
+        ]
+      }
     }
-  }
-});
+  };
+
+  // add an alias for 'sync' so that will work with both 'sync' and 'sync-app'
+  ret.services['sync-app'] = ret.services.sync;
+  return ret;
+};
 export default framework;

--- a/ui/src/components/configuration/sdk-config-docs/ionic.js
+++ b/ui/src/components/configuration/sdk-config-docs/ionic.js
@@ -1,114 +1,120 @@
-const framework = docsVersion => ({
-  icon: '/img/ionic.svg',
-  title: 'Ionic',
-  steps: [
-    {
-      introduction: 'Create the `mobile-services.json` file.',
-      commands: [
-        'Create a file called `mobile-services.json` in the `src` directory of your Ionic project',
-        'Copy the contents from the panel on the right and paste them into this new file'
-      ]
-    },
-    {
-      introduction:
-        'Install the Core AeroGear module, the module manages and binds all services together on the client side.',
-      commands: [
-        'Open a terminal and navigate to your appplication project root folder.',
-        ['Install AeroGear Core package, from the terminal, execute:', '```npm install @aerogear/app```']
-      ]
-    },
-    {
-      introduction: 'Initialize AeroGear Core module',
-      commands: [
-        [
-          'To init, add the following code in the `src/app/main.ts` file of your project',
-          `\`\`\`js 
+const framework = docsVersion => {
+  const ret = {
+    icon: '/img/ionic.svg',
+    title: 'Ionic',
+    steps: [
+      {
+        introduction: 'Create the `mobile-services.json` file.',
+        commands: [
+          'Create a file called `mobile-services.json` in the `src` directory of your Ionic project',
+          'Copy the contents from the panel on the right and paste them into this new file'
+        ]
+      },
+      {
+        introduction:
+          'Install the Core AeroGear module, the module manages and binds all services together on the client side.',
+        commands: [
+          'Open a terminal and navigate to your appplication project root folder.',
+          ['Install AeroGear Core package, from the terminal, execute:', '```npm install @aerogear/app```']
+        ]
+      },
+      {
+        introduction: 'Initialize AeroGear Core module',
+        commands: [
+          [
+            'To init, add the following code in the `src/app/main.ts` file of your project',
+            `\`\`\`js 
           import { init } from "@aerogear/app";
           declare var require: any;
           // tslint:disable-next-line:no-var-requires
           const appConfig = require("../mobile-services.json");
           init(appConfig);`
+          ]
         ]
-      ]
-    }
-  ],
-  services: {
-    keycloak: {
-      serviceLogoUrl: '/img/keycloak.png',
-      serviceName: 'Identity Management',
-      serviceDescription: 'Identity Management - Identity and Access Management',
-      setupText: 'Identity Management SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/identity-management.html#setup`,
-      steps: [
-        {
-          introduction:
-            'Execute following commands in your project directory to install all necessary NPM packages needed for the Identity Management service:',
-          commands: [['Install the AeroGear Auth package from NPM', '```npm install @aerogear/auth```']]
-        }
-      ]
-    },
-    push: {
-      serviceLogoUrl: '/img/push.png',
-      serviceName: 'Push Notifications',
-      serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
-      setupText: 'Push SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/push-notifications.html#setup`,
-      steps: [
-        {
-          introduction:
-            'Execute following commands in your project directory to install all necessary NPM packages needed for the Push Notifications service:',
-          commands: [
-            ['Install Cordova plugin for push', '```cordova plugin add @aerogear/cordova-plugin-aerogear-push```'],
-            [
-              'Ionic Apps require an additional dependency, the [Ionic Native Push Library](https://ionicframework.com/docs/native/push/)',
-              '```npm install --save @ionic-native/push```'
-            ],
-            [
-              'Install Unified Push Server package needed for Device registration',
-              '```npm install --save @aerogear/push```'
-            ]
-          ]
-        }
-      ]
-    },
-    metrics: {
-      serviceLogoUrl: '/img/metrics.png',
-      serviceName: 'Mobile Metrics',
-      serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
-      setupText: 'Mobile Metrics SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/mobile-metrics.html#setup`,
-      steps: [
-        {
-          introduction:
-            "Metrics is included in all SDK modules, if you already use a component from the AeroGear SDK in your app. You'll need only to install this Cordova plugin to enable it:",
-          commands: [
-            ['Install Metrics Cordova plugin', '```cordova plugin add @aerogear/cordova-plugin-aerogear-metrics```']
-          ]
-        }
-      ]
-    },
-    sync: {
-      serviceLogoUrl: '/img/sync.svg',
-      serviceName: 'Sync',
-      serviceDescription: 'Installs Sync service based on Voyager Server',
-      setupText: 'Sync SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/data-sync.html#setup`,
-
-      steps: [
-        {
-          introduction:
-            'Execute following commands in your project directory to install all necessary NPM packages needed for the Sync service:',
-          commands: [
-            [
+      }
+    ],
+    services: {
+      keycloak: {
+        serviceLogoUrl: '/img/keycloak.png',
+        serviceName: 'Identity Management',
+        serviceDescription: 'Identity Management - Identity and Access Management',
+        setupText: 'Identity Management SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/identity-management.html#setup`,
+        steps: [
+          {
+            introduction:
+              'Execute following commands in your project directory to install all necessary NPM packages needed for the Identity Management service:',
+            commands: [['Install the AeroGear Auth package from NPM', '```npm install @aerogear/auth```']]
+          }
+        ]
+      },
+      push: {
+        serviceLogoUrl: '/img/push.png',
+        serviceName: 'Push Notifications',
+        serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
+        setupText: 'Push SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/push-notifications.html#setup`,
+        steps: [
+          {
+            introduction:
+              'Execute following commands in your project directory to install all necessary NPM packages needed for the Push Notifications service:',
+            commands: [
+              ['Install Cordova plugin for push', '```cordova plugin add @aerogear/cordova-plugin-aerogear-push```'],
               [
-                'Install AeroGear Sync Cordova plugin',
-                '```cordova plugin add @aerogear/cordova-plugin-aerogear-sync```'
+                'Ionic Apps require an additional dependency, the [Ionic Native Push Library](https://ionicframework.com/docs/native/push/)',
+                '```npm install --save @ionic-native/push```'
+              ],
+              [
+                'Install Unified Push Server package needed for Device registration',
+                '```npm install --save @aerogear/push```'
               ]
             ]
-          ]
-        }
-      ]
+          }
+        ]
+      },
+      metrics: {
+        serviceLogoUrl: '/img/metrics.png',
+        serviceName: 'Mobile Metrics',
+        serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
+        setupText: 'Mobile Metrics SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/mobile-metrics.html#setup`,
+        steps: [
+          {
+            introduction:
+              "Metrics is included in all SDK modules, if you already use a component from the AeroGear SDK in your app. You'll need only to install this Cordova plugin to enable it:",
+            commands: [
+              ['Install Metrics Cordova plugin', '```cordova plugin add @aerogear/cordova-plugin-aerogear-metrics```']
+            ]
+          }
+        ]
+      },
+      sync: {
+        serviceLogoUrl: '/img/sync.svg',
+        serviceName: 'Sync',
+        serviceDescription: 'Installs Sync service based on Voyager Server',
+        setupText: 'Sync SDK setup',
+        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/data-sync.html#setup`,
+
+        steps: [
+          {
+            introduction:
+              'Execute following commands in your project directory to install all necessary NPM packages needed for the Sync service:',
+            commands: [
+              [
+                [
+                  'Install AeroGear Sync Cordova plugin',
+                  '```cordova plugin add @aerogear/cordova-plugin-aerogear-sync```'
+                ]
+              ]
+            ]
+          }
+        ]
+      }
     }
-  }
-});
+  };
+
+  // add an alias for 'sync' so that will work with both 'sync' and 'sync-app'
+  ret.services['sync-app'] = ret.services.sync;
+  return ret;
+};
 export default framework;

--- a/ui/src/components/configuration/sdk-config-docs/sdkdocs-test-data.js
+++ b/ui/src/components/configuration/sdk-config-docs/sdkdocs-test-data.js
@@ -40,6 +40,13 @@ export const appJSON = {
         config: {}
       },
       {
+        id: '787d9e34-f41d-11e8-b76d-0af08791569c',
+        name: 'badservice',
+        type: 'bad-service-type',
+        url: 'https://data-sync-server-myproject.comm2.skunkhenry.com/graphql',
+        config: {}
+      },
+      {
         id: '93cdd27e-f41d-11e8-b76d-0af08791569c',
         name: 'ups',
         type: 'push',


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8604

## What
- Added a check to avoid crashing in case of unknown service types
- Added unit tests to verify this specific issue

## Why
When bound, the sync service app was expected to be of type `sync` instead of `sync-app` (see [here](https://github.com/aerogearcatalog/sync-app-apb/blob/master/roles/bind-sync-app-apb/tasks/main.yml#L42)).

## Verification Steps
 
1. Create a new app in MDC
2. Provision the sync-app into the MDC project
3. Bind the sync-app to the app you created in step 1
4. Open the app details, go to the configuration tab and click on ionic and/or cordova

Without this fix, it will crash. With this fix, an error will be logged into the console.