### PR TITLE
fix: make the docs url configurable via env var

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	WsWriteWait     int
 	WsPongWait      int
 	BuildTabEnabled bool
-	DocsVersion     string
+	DocsPrefix      string
 }
 
 func GetConfig() Config {
@@ -30,7 +30,7 @@ func GetConfig() Config {
 		WsWriteWait:     getEnvAsInt("WS_WRITE_WAIT", 10),
 		WsPongWait:      getEnvAsInt("WS_PONG_WAIT", 60),
 		BuildTabEnabled: getEnvAsBool("ENABLE_BUILD_TAB", false),
-		DocsVersion:     getEnv("AEROGEAR_DOCS_VERSION", "latest"),
+		DocsPrefix:      getEnv("DOCS_PREFIX", "https://docs.aerogear.org/aerogear/latest"),
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	expected := Config{ListenAddress: ":4000", LogLevel: "info", LogFormat: "text", ApiRoutePrefix: "/api", WsWriteWait: 10, WsPongWait: 60, BuildTabEnabled: false, DocsVersion: "latest"}
+	expected := Config{ListenAddress: ":4000", LogLevel: "info", LogFormat: "text", ApiRoutePrefix: "/api", WsWriteWait: 10, WsPongWait: 60, BuildTabEnabled: false, DocsPrefix: "https://docs.aerogear.org/aerogear/latest"}
 	config := GetConfig()
 
 	if !reflect.DeepEqual(expected, config) {
@@ -16,12 +16,12 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigEnvironmentVariables(t *testing.T) {
-	expected := Config{ListenAddress: ":5000", LogLevel: "info", LogFormat: "text", ApiRoutePrefix: "/api", WsWriteWait: 10, WsPongWait: 60, BuildTabEnabled: true, DocsVersion: "1.1"}
+	expected := Config{ListenAddress: ":5000", LogLevel: "info", LogFormat: "text", ApiRoutePrefix: "/api", WsWriteWait: 10, WsPongWait: 60, BuildTabEnabled: true, DocsPrefix: "1.1"}
 
 	os.Setenv("PORT", "5000")
 	os.Setenv("RESYNC_PERIOD", "20")
 	os.Setenv("ENABLE_BUILD_TAB", "true")
-	os.Setenv("AEROGEAR_DOCS_VERSION", "1.1")
+	os.Setenv("DOCS_PREFIX", "1.1")
 
 	config := GetConfig()
 

--- a/pkg/web/serverConfigHandler.go
+++ b/pkg/web/serverConfigHandler.go
@@ -16,7 +16,7 @@ type ServerConfigHandler struct {
 }
 
 const tmpl = `
-window.SERVER_DATA='{"ENABLE_BUILD_TAB":{{.BuildTabEnabled}},"AEROGEAR_DOCS_VERSION":"{{.DocsVersion}}"}';
+window.SERVER_DATA='{"ENABLE_BUILD_TAB":{{.BuildTabEnabled}},"DOCS_PREFIX":"{{.DocsPrefix}}"}';
 `
 
 func NewServerConfigHandler(config config.Config) *ServerConfigHandler {

--- a/ui/node_modules/.hooks/preinstall
+++ b/ui/node_modules/.hooks/preinstall
@@ -1,9 +1,0 @@
-#!/usr/bin/bash
-
-# This script should only execute when npm run with mvn
-if [[ ! -z ${MAVEN_PROJECTBASEDIR} && ${npm_package_name} == node-sass ]]
-then
-    echo "Running node-gyp for node-sass in preinstall"
-    ${npm_config_prefix}/node_modules/node-gyp/bin/node-gyp.js rebuild \
-                        --dist-url=${npm_config_dist_url}
-fi

--- a/ui/src/components/configuration/ConfigurationView.js
+++ b/ui/src/components/configuration/ConfigurationView.js
@@ -19,7 +19,7 @@ class ConfigurationView extends Component {
               {Object.keys(frameworks).map(key => (
                 <FrameworkSDKDocs
                   key={key}
-                  framework={frameworks[key](this.props.docsVersion)}
+                  framework={frameworks[key](this.props.docsPrefix)}
                   mobileApp={this.props.app}
                 />
               ))}
@@ -39,7 +39,7 @@ class ConfigurationView extends Component {
 
 function mapStateToProps(state) {
   return {
-    docsVersion: state.config.docsVersion
+    docsPrefix: state.config.docsPrefix
   };
 }
 

--- a/ui/src/components/configuration/sdk-config-docs/cordova.js
+++ b/ui/src/components/configuration/sdk-config-docs/cordova.js
@@ -1,4 +1,4 @@
-const framework = docsVersion => {
+const framework = docsPrefix => {
   const ret = {
     icon: '/img/cordova.png',
     title: 'Cordova',
@@ -41,7 +41,7 @@ const framework = docsVersion => {
         serviceName: 'Identity Management',
         serviceDescription: 'Identity Management - Identity and Access Management',
         setupText: 'Identity Management SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/identity-management.html#setup`,
+        docsLink: `${docsPrefix}/identity-management.html`,
         steps: [
           {
             introduction:
@@ -55,7 +55,7 @@ const framework = docsVersion => {
         serviceName: 'Push Notifications',
         serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
         setupText: 'Push SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/push-notifications.html#setup`,
+        docsLink: `${docsPrefix}/push-notifications.html`,
         steps: [
           {
             introduction:
@@ -72,7 +72,7 @@ const framework = docsVersion => {
         serviceName: 'Mobile Metrics',
         serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
         setupText: 'Mobile Metrics SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/mobile-metrics.html#setup`,
+        docsLink: `${docsPrefix}/mobile-metrics.html`,
         steps: [
           {
             introduction:
@@ -88,7 +88,7 @@ const framework = docsVersion => {
         serviceName: 'Sync',
         serviceDescription: 'Installs Sync service based on Voyager Server',
         setupText: 'Sync SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/data-sync.html#setup`,
+        docsLink: `${docsPrefix}/data-sync.html`,
 
         steps: [
           {

--- a/ui/src/components/configuration/sdk-config-docs/ionic.js
+++ b/ui/src/components/configuration/sdk-config-docs/ionic.js
@@ -1,4 +1,4 @@
-const framework = docsVersion => {
+const framework = docsPrefix => {
   const ret = {
     icon: '/img/ionic.svg',
     title: 'Ionic',
@@ -39,7 +39,7 @@ const framework = docsVersion => {
         serviceName: 'Identity Management',
         serviceDescription: 'Identity Management - Identity and Access Management',
         setupText: 'Identity Management SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/identity-management.html#setup`,
+        docsLink: `${docsPrefix}/identity-management.html`,
         steps: [
           {
             introduction:
@@ -53,7 +53,7 @@ const framework = docsVersion => {
         serviceName: 'Push Notifications',
         serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
         setupText: 'Push SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/push-notifications.html#setup`,
+        docsLink: `${docsPrefix}/push-notifications.html`,
         steps: [
           {
             introduction:
@@ -77,7 +77,7 @@ const framework = docsVersion => {
         serviceName: 'Mobile Metrics',
         serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
         setupText: 'Mobile Metrics SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/mobile-metrics.html#setup`,
+        docsLink: `${docsPrefix}/mobile-metrics.html`,
         steps: [
           {
             introduction:
@@ -93,7 +93,7 @@ const framework = docsVersion => {
         serviceName: 'Sync',
         serviceDescription: 'Installs Sync service based on Voyager Server',
         setupText: 'Sync SDK setup',
-        docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/data-sync.html#setup`,
+        docsLink: `${docsPrefix}/data-sync.html`,
 
         steps: [
           {

--- a/ui/src/components/configuration/sdk-config-docs/sdkdocs-test-data.js
+++ b/ui/src/components/configuration/sdk-config-docs/sdkdocs-test-data.js
@@ -63,7 +63,7 @@ export const appJSON = {
   }
 };
 
-export const framework = docsVersion => ({
+export const framework = docsPrefix => ({
   icon: '/img/xx.png',
   title: 'TestFramework',
   steps: [
@@ -82,7 +82,7 @@ export const framework = docsVersion => ({
       serviceName: 'Identity Management',
       serviceDescription: 'Identity Management - Identity and Access Management',
       setupText: 'Identity Management SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/identity-management.html#setup`,
+      docsLink: `${docsPrefix}/identity-management.html`,
       steps: [
         {
           introduction:
@@ -96,7 +96,7 @@ export const framework = docsVersion => ({
       serviceName: 'Push Notifications',
       serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
       setupText: 'Push SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/push-notifications.html#setup`,
+      docsLink: `${docsPrefix}/push-notifications.html`,
       steps: [
         {
           introduction:
@@ -119,7 +119,7 @@ export const framework = docsVersion => ({
       serviceName: 'Mobile Metrics',
       serviceDescription: 'Installs a metrics service based on Prometheus and Grafana',
       setupText: 'Mobile Metrics SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/mobile-metrics.html#setup`,
+      docsLink: `${docsPrefix}/mobile-metrics.html`,
       steps: [
         {
           introduction:
@@ -138,7 +138,7 @@ export const framework = docsVersion => ({
       serviceName: 'Sync',
       serviceDescription: 'Sync service blabla',
       setupText: 'Sync SDK setup',
-      docsLink: `https://docs.aerogear.org/aerogear/${docsVersion}/data-sync.html#setup`,
+      docsLink: `${docsPrefix}/data-sync.html#setup`,
 
       steps: [
         {

--- a/ui/src/containers/Header.js
+++ b/ui/src/containers/Header.js
@@ -9,12 +9,12 @@ class Header extends Component {
   }
 
   render() {
-    const { user } = this.props;
+    const { user, docsPrefix } = this.props;
     const helpDropdowns = [
       {
         text: 'Documentation',
         // TODO: once there is a documentation for MDC, this link should point straight to it
-        href: 'http://docs.aerogear.org/'
+        href: `${docsPrefix}/getting-started.html`
       }
     ];
     const userDropdowns = [
@@ -38,7 +38,8 @@ class Header extends Component {
 
 function mapStateToProps(state) {
   return {
-    user: state.user.currentUser
+    user: state.user.currentUser,
+    docsPrefix: state.config.docsPrefix
   };
 }
 

--- a/ui/src/reducers/config.js
+++ b/ui/src/reducers/config.js
@@ -1,15 +1,15 @@
 let buildTabEnabled = false;
-let docsVersion = 'latest';
+let docsPrefix = 'https://docs.aerogear.org/aerogear/latest';
 
 if (window && window.SERVER_DATA) {
   const serverConfig = JSON.parse(window.SERVER_DATA);
   buildTabEnabled = serverConfig.ENABLE_BUILD_TAB;
-  docsVersion = serverConfig.AEROGEAR_DOCS_VERSION;
+  docsPrefix = serverConfig.DOCS_PREFIX;
 }
 
 const defaultState = {
   buildTabEnabled,
-  docsVersion
+  docsPrefix
 };
 
 const r = (state = defaultState) =>


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8534


## Verification Steps

1. run mdc as normal. the docs link should continue to work and point to docs.aerogear.org.
2. set an env var `DOCS_PREFIX=<any http url>` and run mdc again. This time you should see the docs point to the new url. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

 

