### PR TITLE
build: added a script to enable Node.js debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "start-js": "react-scripts start",
     "start:client": "npm-run-all -p watch-css start-js",
     "start:server": "nodemon --watch server/server.js --exec 'node server/server.js'",
+    "debug:server": "nodemon --watch server/server.js --exec 'node --inspect server/server.js'",
     "build-js": "react-scripts build",
     "build": "npm-run-all build-css build-js",
     "test": "react-scripts test --env=jsdom --transformIgnorePatterns \"node_modules/(?!lodash-es)/\"",


### PR DESCRIPTION
## Motivation

To enable debugging of the Node.js server.

## What

Added an NPM to start the server with the `--inspect` flag, which enables a process to listen for a debugging client.

For more see [Node.js - Debugging](https://nodejs.org/de/docs/guides/debugging-getting-started/).

## Why

Running `npm run debug:server` allows code editor to attach to the server and we can debug the server from the editor.

## Verification Steps

1. Run `npm run debug:server`
2. The server should start with an extra debugger process. The message below should be output in your console.

```sh
Debugger listening on ws://127.0.0.1:9229/a1d95372-f750-4e53-90a4-92b82dc816a9
```
 
## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

