### PR TITLE
Added test cases for BuildConfigDetails component

### DIFF
--- a/src/components/build/BuildConfigDetails.test.js
+++ b/src/components/build/BuildConfigDetails.test.js
@@ -1,0 +1,85 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import BuildConfigDetails from './BuildConfigDetails';
+
+const setup = (propOverrides = {}) => {
+  const defaultProps = {
+    buildConfig: {
+      repoUrl: 'http://example.com',
+      branch: 'example-branch',
+      jobName: 'job-11010',
+      jenkinsfilePath: 'https://jenkins.file/path'
+    }
+  };
+
+  const props = { ...defaultProps, propOverrides };
+  const wrapper = shallow(<BuildConfigDetails {...props} />);
+
+  return {
+    props,
+    wrapper
+  };
+};
+
+describe('BuildConfigDetails', () => {
+  const {
+    props: {
+      buildConfig: { repoUrl, branch, jobName, jenkinsfilePath }
+    },
+    wrapper
+  } = setup();
+
+  it('should render component', () => {
+    expect(wrapper).toHaveLength(1);
+    expect(wrapper.find('Row')).toHaveLength(2);
+
+    describe('First Row', () => {
+      const firstRow = wrapper.childAt(0);
+
+      expect(firstRow.name()).toEqual('Row');
+
+      expect(firstRow.find('Col')).toHaveLength(2);
+
+      expect(
+        firstRow
+          .childAt(0)
+          .find('a')
+          .props().href
+      ).toEqual(repoUrl);
+
+      expect(
+        firstRow
+          .childAt(0)
+          .find('a')
+          .text()
+      ).toEqual(repoUrl);
+
+      expect(
+        firstRow
+          .childAt(1)
+          .find('span')
+          .text()
+      ).toEqual(branch);
+    });
+  });
+
+  describe('Second Row', () => {
+    const secondRow = wrapper.childAt(1);
+
+    expect(secondRow.name()).toEqual('Row');
+
+    expect(
+      secondRow
+        .childAt(0)
+        .find('span')
+        .text()
+    ).toEqual(jobName);
+
+    expect(
+      secondRow
+        .childAt(1)
+        .find('span')
+        .text()
+    ).toEqual(jenkinsfilePath);
+  });
+});


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9324

## What

Added a new test file and achieved 100% coverage for the [`BuildConfigDetails.js`](https://github.com/craicoverflow/mobile-developer-console/blob/56b14ca4f199af2297e24d57b716f2a64b9b6820/src/components/build/BuildConfigDetails.js) component.

## Why

There were no tests created for this file.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run `npm run coverage | grep 'BuildConfigDetails.js\|Lines`
2. You should see the coverage of this component is at 100%.
3. Inspect the test file to ensure that the cases are satisfactory.