### PR TITLE
test: added tests for BuildInformation component

### DIFF
--- a/src/components/build/BuildInformation.test.js
+++ b/src/components/build/BuildInformation.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import BuildInformation from './BuildInformation';
+
+const setup = (propOverrides = {}) => {
+  const defaultProps = {
+    build: {},
+    appName: ''
+  };
+
+  const props = { ...defaultProps, propOverrides };
+  const wrapper = shallow(<BuildInformation {...props} />);
+
+  return { props, wrapper };
+};
+
+describe('BuildInformation', () => {
+  const {
+    props: { build },
+    wrapper
+  } = setup({
+    appName: 'myapp',
+    build: {
+      buildUrl: 'http://build.url',
+      metadata: {
+        annotations: {
+          name: 'myapp',
+          'aerogear.org/download-mobile-artifact': 'hello-world',
+          'aerogear.org/download-mobile-artifact-url': 'http://download.url',
+          'openshift.io/build-config.name': 'build-config'
+        }
+      }
+    }
+  });
+
+  it('should render', () => {
+    expect(wrapper).toHaveLength(1);
+  });
+
+  describe('BuildSummary', () => {
+    it('should render', () => {
+      const BuildSummary = wrapper.find('BuildSummary');
+
+      expect(BuildSummary).toHaveLength(1);
+      expect(BuildSummary.props().build).toEqual(build);
+    });
+  });
+
+  describe('BuildPipelineStage', () => {
+    it('should render', () => {
+      const BuildPipelineStage = wrapper.find('BuildPipelineStage');
+
+      expect(BuildPipelineStage).toHaveLength(1);
+      expect(BuildPipelineStage.props().build).toEqual(build);
+    });
+  });
+
+  describe('BuildDownload', () => {
+    it('should match previous snapshot', () => {
+      const BuildDownload = wrapper.find('BuildDownload');
+
+      expect(BuildDownload).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/build/__snapshots__/BuildInformation.test.js.snap
+++ b/src/components/build/__snapshots__/BuildInformation.test.js.snap
@@ -1,0 +1,822 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BuildInformation BuildDownload should match previous snapshot 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): ShallowWrapper {
+    Symbol(enzyme.__root__): [Circular],
+    Symbol(enzyme.__unrendered__): <BuildInformation
+      appName=""
+      build={Object {}}
+      propOverrides={
+        Object {
+          "appName": "myapp",
+          "build": Object {
+            "buildUrl": "http://build.url",
+            "metadata": Object {
+              "annotations": Object {
+                "aerogear.org/download-mobile-artifact": "hello-world",
+                "aerogear.org/download-mobile-artifact-url": "http://download.url",
+                "name": "myapp",
+                "openshift.io/build-config.name": "build-config",
+              },
+            },
+          },
+        }
+      }
+    />,
+    Symbol(enzyme.__renderer__): Object {
+      "batchedUpdates": [Function],
+      "checkPropTypes": [Function],
+      "getNode": [Function],
+      "render": [Function],
+      "simulateError": [Function],
+      "simulateEvent": [Function],
+      "unmount": [Function],
+    },
+    Symbol(enzyme.__node__): Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <div
+          className="latest-mobile-build"
+        >
+          <Col
+            bsClass="col"
+            className="latest-build-pipeline"
+            componentClass="div"
+            md={10}
+          >
+            <div
+              className="build-pipeline"
+            >
+              <BuildSummary
+                build={Object {}}
+              />
+              <div
+                className="pipeline-container"
+              >
+                <div
+                  className="pipeline"
+                >
+                  <BuildPipelineStage
+                    build={Object {}}
+                  />
+                </div>
+              </div>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            className="latest-download-trigger"
+            componentClass="div"
+            md={2}
+          >
+            <Connect(BuildDownload)
+              appName=""
+              build={Object {}}
+            />
+          </Col>
+        </div>,
+        "className": "build-information",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <Col
+              bsClass="col"
+              className="latest-build-pipeline"
+              componentClass="div"
+              md={10}
+            >
+              <div
+                className="build-pipeline"
+              >
+                <BuildSummary
+                  build={Object {}}
+                />
+                <div
+                  className="pipeline-container"
+                >
+                  <div
+                    className="pipeline"
+                  >
+                    <BuildPipelineStage
+                      build={Object {}}
+                    />
+                  </div>
+                </div>
+              </div>
+            </Col>,
+            <Col
+              bsClass="col"
+              className="latest-download-trigger"
+              componentClass="div"
+              md={2}
+            >
+              <Connect(BuildDownload)
+                appName=""
+                build={Object {}}
+              />
+            </Col>,
+          ],
+          "className": "latest-mobile-build",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "bsClass": "col",
+              "children": <div
+                className="build-pipeline"
+              >
+                <BuildSummary
+                  build={Object {}}
+                />
+                <div
+                  className="pipeline-container"
+                >
+                  <div
+                    className="pipeline"
+                  >
+                    <BuildPipelineStage
+                      build={Object {}}
+                    />
+                  </div>
+                </div>
+              </div>,
+              "className": "latest-build-pipeline",
+              "componentClass": "div",
+              "md": 10,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <BuildSummary
+                    build={Object {}}
+                  />,
+                  <div
+                    className="pipeline-container"
+                  >
+                    <div
+                      className="pipeline"
+                    >
+                      <BuildPipelineStage
+                        build={Object {}}
+                      />
+                    </div>
+                  </div>,
+                ],
+                "className": "build-pipeline",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "build": Object {},
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <div
+                      className="pipeline"
+                    >
+                      <BuildPipelineStage
+                        build={Object {}}
+                      />
+                    </div>,
+                    "className": "pipeline-container",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <BuildPipelineStage
+                        build={Object {}}
+                      />,
+                      "className": "pipeline",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "build": Object {},
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "bsClass": "col",
+              "children": <Connect(BuildDownload)
+                appName=""
+                build={Object {}}
+              />,
+              "className": "latest-download-trigger",
+              "componentClass": "div",
+              "md": 2,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "appName": "",
+                "build": Object {},
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": [Function],
+          },
+        ],
+        "type": "div",
+      },
+      "type": "div",
+    },
+    Symbol(enzyme.__nodes__): Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <div
+            className="latest-mobile-build"
+          >
+            <Col
+              bsClass="col"
+              className="latest-build-pipeline"
+              componentClass="div"
+              md={10}
+            >
+              <div
+                className="build-pipeline"
+              >
+                <BuildSummary
+                  build={Object {}}
+                />
+                <div
+                  className="pipeline-container"
+                >
+                  <div
+                    className="pipeline"
+                  >
+                    <BuildPipelineStage
+                      build={Object {}}
+                    />
+                  </div>
+                </div>
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              className="latest-download-trigger"
+              componentClass="div"
+              md={2}
+            >
+              <Connect(BuildDownload)
+                appName=""
+                build={Object {}}
+              />
+            </Col>
+          </div>,
+          "className": "build-information",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <Col
+                bsClass="col"
+                className="latest-build-pipeline"
+                componentClass="div"
+                md={10}
+              >
+                <div
+                  className="build-pipeline"
+                >
+                  <BuildSummary
+                    build={Object {}}
+                  />
+                  <div
+                    className="pipeline-container"
+                  >
+                    <div
+                      className="pipeline"
+                    >
+                      <BuildPipelineStage
+                        build={Object {}}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </Col>,
+              <Col
+                bsClass="col"
+                className="latest-download-trigger"
+                componentClass="div"
+                md={2}
+              >
+                <Connect(BuildDownload)
+                  appName=""
+                  build={Object {}}
+                />
+              </Col>,
+            ],
+            "className": "latest-mobile-build",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "bsClass": "col",
+                "children": <div
+                  className="build-pipeline"
+                >
+                  <BuildSummary
+                    build={Object {}}
+                  />
+                  <div
+                    className="pipeline-container"
+                  >
+                    <div
+                      className="pipeline"
+                    >
+                      <BuildPipelineStage
+                        build={Object {}}
+                      />
+                    </div>
+                  </div>
+                </div>,
+                "className": "latest-build-pipeline",
+                "componentClass": "div",
+                "md": 10,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <BuildSummary
+                      build={Object {}}
+                    />,
+                    <div
+                      className="pipeline-container"
+                    >
+                      <div
+                        className="pipeline"
+                      >
+                        <BuildPipelineStage
+                          build={Object {}}
+                        />
+                      </div>
+                    </div>,
+                  ],
+                  "className": "build-pipeline",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "function",
+                    "props": Object {
+                      "build": Object {},
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <div
+                        className="pipeline"
+                      >
+                        <BuildPipelineStage
+                          build={Object {}}
+                        />
+                      </div>,
+                      "className": "pipeline-container",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <BuildPipelineStage
+                          build={Object {}}
+                        />,
+                        "className": "pipeline",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "build": Object {},
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": "div",
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "bsClass": "col",
+                "children": <Connect(BuildDownload)
+                  appName=""
+                  build={Object {}}
+                />,
+                "className": "latest-download-trigger",
+                "componentClass": "div",
+                "md": 2,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "appName": "",
+                  "build": Object {},
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+          ],
+          "type": "div",
+        },
+        "type": "div",
+      },
+    ],
+    Symbol(enzyme.__options__): Object {
+      "adapter": ReactSixteenAdapter {
+        "options": Object {
+          "enableComponentDidUpdateOnSetState": true,
+          "legacyContextMode": "parent",
+          "lifecycles": Object {
+            "componentDidUpdate": Object {
+              "onSetState": true,
+            },
+            "getChildContext": Object {
+              "calledByRenderer": false,
+            },
+            "getDerivedStateFromError": true,
+            "getDerivedStateFromProps": Object {
+              "hasShouldComponentUpdateBug": false,
+            },
+            "getSnapshotBeforeUpdate": true,
+            "setState": Object {
+              "skipsComponentDidUpdateOnNullish": true,
+            },
+          },
+        },
+      },
+    },
+  },
+  Symbol(enzyme.__unrendered__): null,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): undefined,
+  Symbol(enzyme.__nodes__): Array [],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromError": true,
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+  Symbol(enzyme.__rootNodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <div
+          className="latest-mobile-build"
+        >
+          <Col
+            bsClass="col"
+            className="latest-build-pipeline"
+            componentClass="div"
+            md={10}
+          >
+            <div
+              className="build-pipeline"
+            >
+              <BuildSummary
+                build={Object {}}
+              />
+              <div
+                className="pipeline-container"
+              >
+                <div
+                  className="pipeline"
+                >
+                  <BuildPipelineStage
+                    build={Object {}}
+                  />
+                </div>
+              </div>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            className="latest-download-trigger"
+            componentClass="div"
+            md={2}
+          >
+            <Connect(BuildDownload)
+              appName=""
+              build={Object {}}
+            />
+          </Col>
+        </div>,
+        "className": "build-information",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <Col
+              bsClass="col"
+              className="latest-build-pipeline"
+              componentClass="div"
+              md={10}
+            >
+              <div
+                className="build-pipeline"
+              >
+                <BuildSummary
+                  build={Object {}}
+                />
+                <div
+                  className="pipeline-container"
+                >
+                  <div
+                    className="pipeline"
+                  >
+                    <BuildPipelineStage
+                      build={Object {}}
+                    />
+                  </div>
+                </div>
+              </div>
+            </Col>,
+            <Col
+              bsClass="col"
+              className="latest-download-trigger"
+              componentClass="div"
+              md={2}
+            >
+              <Connect(BuildDownload)
+                appName=""
+                build={Object {}}
+              />
+            </Col>,
+          ],
+          "className": "latest-mobile-build",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "bsClass": "col",
+              "children": <div
+                className="build-pipeline"
+              >
+                <BuildSummary
+                  build={Object {}}
+                />
+                <div
+                  className="pipeline-container"
+                >
+                  <div
+                    className="pipeline"
+                  >
+                    <BuildPipelineStage
+                      build={Object {}}
+                    />
+                  </div>
+                </div>
+              </div>,
+              "className": "latest-build-pipeline",
+              "componentClass": "div",
+              "md": 10,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <BuildSummary
+                    build={Object {}}
+                  />,
+                  <div
+                    className="pipeline-container"
+                  >
+                    <div
+                      className="pipeline"
+                    >
+                      <BuildPipelineStage
+                        build={Object {}}
+                      />
+                    </div>
+                  </div>,
+                ],
+                "className": "build-pipeline",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "build": Object {},
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <div
+                      className="pipeline"
+                    >
+                      <BuildPipelineStage
+                        build={Object {}}
+                      />
+                    </div>,
+                    "className": "pipeline-container",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <BuildPipelineStage
+                        build={Object {}}
+                      />,
+                      "className": "pipeline",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "build": Object {},
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "bsClass": "col",
+              "children": <Connect(BuildDownload)
+                appName=""
+                build={Object {}}
+              />,
+              "className": "latest-download-trigger",
+              "componentClass": "div",
+              "md": 2,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "appName": "",
+                "build": Object {},
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": [Function],
+          },
+        ],
+        "type": "div",
+      },
+      "type": "div",
+    },
+  ],
+}
+`;


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9325

## What

Added a test file for the `BuildInformation` component.

## Why

Previously there were none.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run `npm run coverage | grep 'Lines\|BuildInformation.js'`
2. The coverage level should be at 100%.
