### PR TITLE
fix: missing oauth client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,21 @@
     ```
     oc login <openshift-url>
     ```
-2. Deploy the service using one of the following commands:
+2. Export `NAMESPACE` and `OPENSHIFT_HOST` variables and run [`prepare.sh`](scripts/prepare.sh) script:
+   ```
+   export NAMESPACE="<your-project-name>"
+   export OPENSHIFT_HOST="<your-openshift-host>"
+   ./scripts/prepare.sh
+   ```
+3. Deploy the service using one of the following commands:
    ```
    # Deploy the latest image
-   ./deploy/deploy-image.sh <openshift-host> <namespace>
+   ./deploy/deploy-image.sh $OPENSHIFT_HOST $NAMESPACE
 
    # OR deploy the service using S2I
-   ./deploy/deploy-image-stream.sh <openshift-host> <namespace> <git-ref>
+   ./deploy/deploy-image-stream.sh $OPENSHIFT_HOST $NAMESPACE <git-ref>
    ```
-3. [Enable CORS](#enable-cors-in-the-openshift-cluster)
+4. [Enable CORS](#enable-cors-in-the-openshift-cluster)
 
 ## Development
 


### PR DESCRIPTION
## Motivation
By following the steps here, a user gets this error if a new cluster is used to deploy MDC for the first time:
```
Error from server (NotFound): oauthclients.oauth.openshift.io "mobile-developer-console" not found
```

## Verification Steps
1. Target a new remote OpenShift cluster
2. Follow the steps from [here](https://github.com/aerogear/mobile-developer-console#remote-cluster)
3. Make sure that mdc is deployed successfully and you can log in to MDC as well

