### PR TITLE
fix: make entire MobileClientCardViewItem component clickable

### DIFF
--- a/src/components/overview/MobileClientCardViewItem.js
+++ b/src/components/overview/MobileClientCardViewItem.js
@@ -33,18 +33,18 @@ const MobileClientCardViewItem = props => {
   return (
     <div className="col-xs-12 col-sm-6 col-md-4 col-lg-3">
       <Card matchHeight /* accented */ className="mobile-client-card">
-        <CardHeading>
-          <DropdownKebab id={app.metadata.name} pullRight className="card-dropdown-kebab">
-            <EditItemButton item={app} />
-            <DeleteItemButton itemType="app" itemName={appName} item={app} />
-          </DropdownKebab>
-          <Link to={`/mobileclient/${app.metadata.name}`}>
-            <div className="card-pf-title">
-              <h1>{app.spec.name}</h1>
-            </div>
-          </Link>
-        </CardHeading>
         <Link to={`/mobileclient/${app.metadata.name}`}>
+          <CardHeading>
+            <DropdownKebab id={app.metadata.name} pullRight className="card-dropdown-kebab">
+              <EditItemButton item={app} />
+              <DeleteItemButton itemType="app" itemName={appName} item={app} />
+            </DropdownKebab>
+            <Link to={`/mobileclient/${app.metadata.name}`}>
+              <div className="card-pf-title">
+                <h1>{app.spec.name}</h1>
+              </div>
+            </Link>
+          </CardHeading>
           <CardBody>
             <div className="card-icons">
               {services && services.length > 0 ? getServiceIcons(services) : <div className="service-icon" />}


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9337

## What

This change made the whole `MobileClientCardViewItem` component into a clickable link.

## Why

Previously there was a section below the card title that did not do anything when clicked.

## How

Moved the opening tag of the `Link` component up to become the first child in the `Card` component.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run the MDC following the steps [outlined in the README](https://github.com/aerogear/mobile-developer-console#try-it-out).
2. Create a mobile app if one does not exist.
3. Click the app card item below the title. It should navigate you to the MobileClient view. This did not work before. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task