### PR TITLE
build(gitignore): removed obsolete values from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,3 @@ yarn-error.log*
 node
 npm-cache
 target
-build


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9338

## What

Removed references to obsolete files, extensions and directories.

## Why

The `.gitignore` file retained references to files, extensions and directories that no longer exist since the MDC refactor.

## Verification Steps

N/A