### PR TITLE
style(lint): wrapped string to new line to fix linting error

### DIFF
--- a/src/services/openshift.js
+++ b/src/services/openshift.js
@@ -63,9 +63,8 @@ const getUser = () => {
 const get = (res, name) =>
   getUser().then(user =>
     axios({
-      url: `${window.OPENSHIFT_CONFIG.masterUri}/apis/${res.group}/${res.version}/namespaces/${res.namespace}/${
-        res.name
-      }/${name}`,
+      url: `${window.OPENSHIFT_CONFIG.masterUri}/apis/${res.group}/${res.version}/namespaces/
+      ${res.namespace}/${res.name}/${name}`,
       headers: {
         authorization: `Bearer ${user.accessToken}`
       }


### PR DESCRIPTION
## Motivation

#267 has one failing check on `nom run lint`. This fixes that.

## Why
Add an short answer for: Why it was done? (E.g The feature X was deprecated.)

## Verification Steps

1. Run `npm lint`.
2. You should not get any errors (you will get warnings, but that is okay).