### PR TITLE
test: added tests for CreateBuildConfigDialog

### DIFF
--- a/src/components/build/CreateBuildConfigDialog.js
+++ b/src/components/build/CreateBuildConfigDialog.js
@@ -8,7 +8,7 @@ import SourceSection from './create_build_config/SourceSection';
 import BuildSection from './create_build_config/BuildSection';
 import { createBuildConfigConnect } from './create_build_config/ReduxCommon';
 
-class CreateBuildConfigDialog extends Component {
+export class CreateBuildConfigDialog extends Component {
   state = { valid: false };
 
   componentDidUpdate(prevProps) {
@@ -74,4 +74,5 @@ class CreateBuildConfigDialog extends Component {
     );
   }
 }
+
 export default createBuildConfigConnect(KEY_CR, configValidation, CreateBuildConfigDialog);

--- a/src/components/build/CreateBuildConfigDialog.js
+++ b/src/components/build/CreateBuildConfigDialog.js
@@ -28,11 +28,6 @@ export class CreateBuildConfigDialog extends Component {
     onSave && onSave({ config });
   };
 
-  cancel = () => {
-    const { onCancel } = this.props;
-    onCancel && onCancel();
-  };
-
   renderFormButtons = (onCancel, valid) => (
     <div>
       <Button onClick={onCancel}>Cancel</Button>
@@ -41,8 +36,6 @@ export class CreateBuildConfigDialog extends Component {
       </Button>
     </div>
   );
-
-  getValidationState = () => {};
 
   render() {
     const { show, title, onCancel } = this.props;

--- a/src/components/build/CreateBuildConfigDialog.test.js
+++ b/src/components/build/CreateBuildConfigDialog.test.js
@@ -1,0 +1,185 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { CreateBuildConfigDialog } from './CreateBuildConfigDialog';
+
+const setup = (propOverrides = {}) => {
+  const defaultProps = {
+    show: false,
+    title: '',
+    onSave: jest.fn(),
+    onCancel: jest.fn()
+  };
+
+  const props = { ...defaultProps, ...propOverrides };
+
+  const wrapper = shallow(<CreateBuildConfigDialog {...props} />);
+
+  return { wrapper, props };
+};
+
+describe('CreateBuildConfigDialog', () => {
+  describe('components should render', () => {
+    const {
+      wrapper,
+      props: { onCancel, show, title }
+    } = setup({
+      title: 'Dialog Title',
+      show: true
+    });
+
+    it('should render', () => {
+      expect(wrapper).toHaveLength(1);
+      expect(wrapper.state('valid')).toBe(false);
+    });
+
+    describe('Modal', () => {
+      const Modal = wrapper.find('Modal');
+
+      it('should render with expected props', () => {
+        expect(Modal).toHaveLength(1);
+        expect(Modal.prop('show')).toBe(show);
+      });
+
+      describe('Modal.Header', () => {
+        const ModalHeader = wrapper.find('ModalHeader');
+
+        it('should render', () => {
+          expect(ModalHeader).toHaveLength(1);
+        });
+
+        describe('Modal.CloseButton', () => {
+          const ModalCloseButton = ModalHeader.find('ModalCloseButton');
+
+          it('should render with expected props', () => {
+            expect(ModalCloseButton).toHaveLength(1);
+            expect(ModalCloseButton.prop('onClick')).toBe(onCancel);
+          });
+        });
+        describe('Modal.Title', () => {
+          const ModalTitle = ModalHeader.find('ModalTitle');
+
+          it('should render', () => {
+            expect(ModalTitle).toHaveLength(1);
+            expect(ModalTitle.render().text()).toBe(title);
+          });
+        });
+      });
+
+      describe('Modal.Body', () => {
+        const ModalBody = Modal.find('ModalBody');
+
+        it('should render with expected props', () => {
+          expect(ModalBody.hasClass('modalBody buildConfigModal')).toBe(true);
+        });
+
+        describe('Grid', () => {
+          const Grid = ModalBody.find('Grid');
+
+          it('should render with expected props', () => {
+            expect(Grid).toHaveLength(1);
+            expect(Grid.prop('fluid')).toBe(true);
+          });
+
+          describe('Row', () => {
+            const Row = Grid.find('Row');
+
+            it('should render', () => {
+              expect(Row).toHaveLength(1);
+            });
+
+            describe('Col', () => {
+              const Col = Row.find('Col');
+
+              it('should render with expected props', () => {
+                expect(Col).toHaveLength(1);
+                expect(Col.prop('md')).toBe(12);
+              });
+
+              it('should render help block', () => {
+                const helpBlock = Col.find('div.help-block');
+                expect(helpBlock).toHaveLength(1);
+              });
+            });
+          });
+        });
+      });
+
+      describe('ModalFooter', () => {
+        const ModalFooter = Modal.find('ModalFooter');
+
+        it('should render', () => {
+          expect(ModalFooter).toHaveLength(1);
+        });
+
+        describe('buttons', () => {
+          const buttons = ModalFooter.find('Button');
+
+          it('should render 2 buttons', () => {
+            expect(buttons).toHaveLength(2);
+          });
+
+          describe('Cancel', () => {
+            const cancelButton = buttons.at(0);
+            it('should render expected props', () => {
+              expect(cancelButton.prop('onClick')).toBe(onCancel);
+            });
+          });
+
+          describe('Save', () => {
+            const saveButton = buttons.at(1);
+
+            it('should render expected props', () => {
+              expect(saveButton.prop('onClick')).toBeInstanceOf(Function);
+              expect(saveButton.prop('disabled')).toBe(!wrapper.state('valid'));
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('events', () => {
+    let wrapper;
+    beforeEach(() => {
+      ({ wrapper } = setup({
+        title: 'Dialog Title',
+        show: true,
+        createBuildConfigState: {
+          config: {
+            name: 'app'
+          },
+          mandatoryFields: {
+            config: {
+              fields: ['name']
+            }
+          }
+        }
+      }));
+    });
+
+    describe('validate()', () => {
+      it('should be called in onReceiveProps()', () => {
+        const spy = jest.spyOn(wrapper.instance(), 'validate');
+        wrapper.setProps({
+          createBuildConfigState: {
+            prop1: 'hello-jupiter'
+          }
+        });
+        wrapper.instance().forceUpdate();
+        expect(spy).toBeCalled();
+        expect(wrapper.state('valid')).toBe(true);
+      });
+    });
+
+    describe('onSaveBuildConfig()', () => {
+      it('should be called on save button click', () => {
+        const spy = jest.spyOn(wrapper.instance(), 'onSaveBuildConfig');
+        wrapper.instance().forceUpdate();
+        const saveButton = wrapper.find('Button').at(1);
+
+        saveButton.simulate('click');
+        expect(spy).toBeCalled();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9367

## What

- Exported the `CreateBuildConfigDialog` class separately from the Redux connect. This allows the class to be tested in isolation.
- Added unit tests for the `CreateBuildConfigDialog` component.
- Removed unused functions from component.

## Why

There were no tests for this file.

## Verification Steps
 
1. Run `npm run coverage | grep 'Lines\|CreateBuildConfig'`
2. Tests should pass and coverage should be at 100%.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO