### PR TITLE
feat(mobile-services.json): populate status object on app create

### DIFF
--- a/src/containers/ClientEditBaseClass.js
+++ b/src/containers/ClientEditBaseClass.js
@@ -17,12 +17,21 @@ class ClientEditBaseClass extends Component {
   }
 
   getMobileAppToEdit(newWindow) {
-    if (!newWindow && this.props.createClientAppDialog.app) {
-      return new MobileApp({ ...this.props.createClientAppDialog.app });
+    const {
+      createClientAppDialog: { app },
+      item
+    } = this.props;
+
+    if (!newWindow && app) {
+      return new MobileApp({
+        ...app,
+        clientId: app.spec.name,
+        services: []
+      });
     }
 
-    if (this.props.item) {
-      return new MobileApp(JSON.parse(JSON.stringify(this.props.item)));
+    if (item) {
+      return new MobileApp(JSON.parse(JSON.stringify(item)));
     }
 
     return new MobileApp();

--- a/src/services/openshift.js
+++ b/src/services/openshift.js
@@ -102,6 +102,10 @@ const create = (res, obj, owner) =>
   getUser().then(user => {
     const requestUrl = _buildRequestUrl(res);
 
+    if (obj.status) {
+      obj.status.namespace = window.OPENSHIFT_CONFIG.mdcNamespace;
+    }
+
     if (!obj.apiVersion) {
       obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
     }


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9423 

## What

On app creation, the `mobile-services.json` object should contain the following properties:

* clientId
* namespaces
* services (empty) 

## Verification Steps
 
1. Run MDC.
2. Create a new app. The `mobile-services.json` should be populate with the following structure:

```json
{
  "clientId": "myapp",
  "namespace": "mobile-console",
  "services": []
}
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO