### PR TITLE
🐛 Fix: filtering edited apps

### DIFF
--- a/src/components/overview/MobileClientCardView.js
+++ b/src/components/overview/MobileClientCardView.js
@@ -83,7 +83,7 @@ class MobileClientCardView extends Component {
     return mobileClients
       .map(app => {
         const {
-          metadata: { name: clientAppName }
+          spec: { name: clientAppName }
         } = app;
         const { filter } = this.state;
         return clientAppName.indexOf(filter) > -1 ? (

--- a/src/components/overview/MobileClientCardView.test.js
+++ b/src/components/overview/MobileClientCardView.test.js
@@ -11,6 +11,9 @@ const setup = (propOverrides = {}) => {
         },
         status: {
           services: []
+        },
+        spec: {
+          name: 'my-app'
         }
       },
       {
@@ -19,6 +22,9 @@ const setup = (propOverrides = {}) => {
         },
         status: {
           services: []
+        },
+        spec: {
+          name: 'your-app'
         }
       }
     ],
@@ -98,6 +104,9 @@ describe('MobileClientCardView', () => {
         },
         status: {
           services: []
+        },
+        spec: {
+          name: 'my-app'
         }
       },
       {
@@ -106,6 +115,9 @@ describe('MobileClientCardView', () => {
         },
         status: {
           services: []
+        },
+        spec: {
+          name: 'my-app-2'
         }
       },
       {
@@ -114,6 +126,9 @@ describe('MobileClientCardView', () => {
         },
         status: {
           services: []
+        },
+        spec: {
+          name: 'your-app'
         }
       }
     ];


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AGMS-233
Updated app were filtered only by original name, not the updated one.

## What
Changed filter function.

## Why
Add an short answer for: Why it was done? (E.g The feature X was deprecated.)

## How
Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) 

## Verification Steps
1. Open MDC
2. Create new app "app"
3. Edit name of your app - change it to something else
4. Try to use filter to find your app by the new name
5. You should be able to find it with the new name and not the original one

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 