### PR TITLE
feat: use metadata.name instead of spec.name

### DIFF
--- a/deploy/mobile-client-crd.yaml
+++ b/deploy/mobile-client-crd.yaml
@@ -21,6 +21,7 @@ spec:
             apiKey:
               type: string
               pattern: '(\w{8}-\w{4}-\w{4}-\w{4}-\w{11})'
+            # `spec.name` is used in OpenShift as the descriptor title of the custom resource
             name:
               type: string
               pattern: '([\w-])'

--- a/src/components/overview/MobileClientCardView.js
+++ b/src/components/overview/MobileClientCardView.js
@@ -83,7 +83,7 @@ class MobileClientCardView extends Component {
     return mobileClients
       .map(app => {
         const {
-          spec: { name: clientAppName }
+          metadata: { name: clientAppName }
         } = app;
         const { filter } = this.state;
         return clientAppName.indexOf(filter) > -1 ? (

--- a/src/components/overview/MobileClientCardViewItem.js
+++ b/src/components/overview/MobileClientCardViewItem.js
@@ -33,16 +33,16 @@ const MobileClientCardViewItem = props => {
     <div className="col-xs-12 col-sm-6 col-md-4 col-lg-3">
       <Card matchHeight /* accented */ className="mobile-client-card">
         <CardHeading>
-          <DropdownKebab id={app.metadata.name} pullRight className="card-dropdown-kebab">
+          <DropdownKebab id={appName} pullRight className="card-dropdown-kebab">
             <DeleteItemButton itemType="app" itemName={appName} item={app} />
           </DropdownKebab>
-          <Link to={`/mobileclient/${app.metadata.name}`}>
+          <Link to={`/mobileclient/${appName}`}>
             <div className="card-pf-title">
-              <h1>{app.spec.name}</h1>
+              <h1>{appName}</h1>
             </div>
           </Link>
         </CardHeading>
-        <Link to={`/mobileclient/${app.metadata.name}`}>
+        <Link to={`/mobileclient/${appName}`}>
           <CardBody>
             <div className="card-icons">
               {services && services.length > 0 ? getServiceIcons(services) : <div className="service-icon" />}

--- a/src/components/overview/MobileClientCardViewItem.js
+++ b/src/components/overview/MobileClientCardViewItem.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { Card, CardHeading, CardBody, CardFooter, DropdownKebab } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 import DeleteItemButton from '../../containers/DeleteItemButton';
-import EditItemButton from '../../containers/EditItemButton';
 
 const getServiceIcons = services => {
   const icons = {
@@ -35,7 +34,6 @@ const MobileClientCardViewItem = props => {
       <Card matchHeight /* accented */ className="mobile-client-card">
         <CardHeading>
           <DropdownKebab id={app.metadata.name} pullRight className="card-dropdown-kebab">
-            <EditItemButton item={app} />
             <DeleteItemButton itemType="app" itemName={appName} item={app} />
           </DropdownKebab>
           <Link to={`/mobileclient/${app.metadata.name}`}>

--- a/src/containers/ClientEditBaseClass.js
+++ b/src/containers/ClientEditBaseClass.js
@@ -24,9 +24,7 @@ class ClientEditBaseClass extends Component {
 
     if (!newWindow && app) {
       return new MobileApp({
-        ...app,
-        clientId: app.spec.name,
-        services: []
+        ...app
       });
     }
 

--- a/src/containers/DeleteItemButton.js
+++ b/src/containers/DeleteItemButton.js
@@ -50,7 +50,7 @@ class DeleteItemButton extends Component {
   };
 
   getItemName() {
-    return this.props.item ? this.props.item.spec.name : this.props.itemName;
+    return this.props.item ? this.props.item.metadata.name : this.props.itemName;
   }
 
   render() {

--- a/src/models/mobileapps/mobileapp.js
+++ b/src/models/mobileapps/mobileapp.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash-es';
 import Metadata from '../k8s/metadata';
-import AppSpec from './mobileappspec';
 import AppStatus from './mobileappstatus';
+import { getNamespace } from '../../services/openshift';
 
 export const PROPERTIES = {
   NAME: 'name'
@@ -64,12 +64,14 @@ export default class MobileApp {
   }
 
   toJSON() {
-    const spec = this.spec.toJSON();
     const metadata = this.metadata.toJSON();
+    const status = this.status.toJSON();
     if (this.isNew) {
-      metadata.name = spec.name;
+      status.clientId = metadata.name;
+      status.services = [];
+      status.namespace = getNamespace();
     }
-    return { ...this.app, spec, metadata, status: this.status.toJSON() };
+    return { ...this.app, metadata, status };
   }
 
   /**

--- a/src/models/mobileapps/mobileapp.js
+++ b/src/models/mobileapps/mobileapp.js
@@ -2,6 +2,7 @@ import { get } from 'lodash-es';
 import Metadata from '../k8s/metadata';
 import AppStatus from './mobileappstatus';
 import { getNamespace } from '../../services/openshift';
+import AppSpec from './mobileappspec';
 
 export const PROPERTIES = {
   NAME: 'name'
@@ -21,7 +22,7 @@ export default class MobileApp {
   }
 
   getName() {
-    return this.getSpec().getName();
+    return this.metadata.getName();
   }
 
   getStatus() {
@@ -66,12 +67,14 @@ export default class MobileApp {
   toJSON() {
     const metadata = this.metadata.toJSON();
     const status = this.status.toJSON();
+    const spec = this.spec.toJSON();
     if (this.isNew) {
-      status.clientId = metadata.name;
+      metadata.name = spec.name;
+      status.clientId = spec.name;
       status.services = [];
       status.namespace = getNamespace();
     }
-    return { ...this.app, metadata, status };
+    return { ...this.app, spec, metadata, status };
   }
 
   /**

--- a/src/services/openshift.js
+++ b/src/services/openshift.js
@@ -102,10 +102,6 @@ const create = (res, obj, owner) =>
   getUser().then(user => {
     const requestUrl = _buildRequestUrl(res);
 
-    if (obj.status) {
-      obj.status.namespace = window.OPENSHIFT_CONFIG.mdcNamespace;
-    }
-
     if (!obj.apiVersion) {
       obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
     }


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9446

## What

1. Remove the ability to edit an app.
2. Use `metadata.name` instead of `spec.name` for the MDC UI.
3. Fixed a bug where the `status` object will not full create sometimes.

## Why

https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/aerogear/UelPDpo2tww

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Create an app in MDC.
2. Try to edit the app. You should not be able to.
3. Edit `spec.name` of the app resource in OpenShift.
4. The name change should not affect the display name in MDC.
5. Verify that the status object is populated with `clientId`, `services` (empty array) and `namespace`.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task