### PR TITLE
Implementing custom resource manager

### DIFF
--- a/src/services/crmanagers/GenericResourceManager.js
+++ b/src/services/crmanagers/GenericResourceManager.js
@@ -1,0 +1,158 @@
+import { map } from 'lodash-es';
+import axios from 'axios';
+import { OpenShiftWatchEvents } from './OpenShiftWatchEvents';
+
+const _buildOpenshiftApiUrl = (baseUrl, res) => (res.group ? `${baseUrl}/apis/${res.group}` : `${baseUrl}/api`);
+
+const _buildOpenShiftUrl = (baseUrl, res) => {
+  const urlBegin = `${_buildOpenshiftApiUrl(baseUrl, res)}/${res.version}`;
+  if (res.namespace) {
+    return `${urlBegin}/namespaces/${res.namespace}/${res.name}`;
+  }
+  return `${urlBegin}/${res.name}`;
+};
+
+const _buildRequestUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.masterUri, res)}`;
+
+const _buildWatchUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.wssMasterUri, res)}?watch=true`;
+
+const _labelsToQuery = labels => {
+  const labelsArr = map(labels, (value, name) => `${name}%3D${value}`);
+  return labelsArr.join(',');
+};
+
+class OpenShiftWatchEventListener {
+  _handler = () => {};
+  _errorHandler = () => {};
+
+  constructor(socket) {
+    this._socket = socket;
+  }
+
+  init() {
+    this._socket.onmessage = event => {
+      const data = JSON.parse(event.data);
+      this._handler({ type: data.type, payload: data.object });
+    };
+    this._socket.oncreate = () => this._handler({ type: OpenShiftWatchEvents.OPENED });
+    this._socket.onclose = () => this._handler({ type: OpenShiftWatchEvents.CLOSED });
+    this._socket.onerror = err => this._errorHandler(err);
+    return this;
+  }
+
+  onEvent(handler) {
+    this._handler = handler;
+    return this;
+  }
+
+  catch(handler) {
+    this._errorHandler = handler;
+    return this;
+  }
+}
+
+/* eslint-disable class-methods-use-this */
+
+export class GenericResourceManager {
+  create(user, res, obj, owner) {
+    const requestUrl = _buildRequestUrl(res);
+
+    if (!obj.apiVersion) {
+      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
+    }
+    if (!obj.kind && res.kind) {
+      obj.kind = res.kind;
+    }
+    if (owner) {
+      obj.metadata.ownerReferences = [
+        {
+          apiVersion: owner.apiVersion,
+          kind: owner.kind,
+          blockOwnerDeletion: false,
+          name: owner.metadata.name,
+          uid: owner.metadata.uid
+        }
+      ];
+    }
+
+    return axios({
+      url: requestUrl,
+      method: 'POST',
+      data: obj,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  remove(user, res, obj) {
+    const requestUrl = _buildRequestUrl(res);
+
+    if (!obj.apiVersion) {
+      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
+    }
+    if (!obj.kind && res.kind) {
+      obj.kind = res.kind;
+    }
+
+    return axios({
+      url: `${requestUrl}/${obj.metadata.name}`,
+      method: 'DELETE',
+      data: {
+        apiVersion: obj.apiVersion,
+        kind: 'DeleteOptions',
+        propogationPolicy: 'Foreground'
+      },
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  update(user, res, obj) {
+    const requestUrl = _buildRequestUrl(res);
+
+    if (!obj.apiVersion) {
+      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
+    }
+
+    return axios({
+      url: `${requestUrl}/${obj.metadata.name}`,
+      method: 'PUT',
+      data: obj,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  list(user, res, labels) {
+    let reqUrl = _buildRequestUrl(res);
+    if (labels) {
+      reqUrl = `${reqUrl}?labelSelector=${_labelsToQuery(labels)}`;
+    }
+    return axios({
+      url: reqUrl,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  watch(user, res) {
+    const watchUrl = _buildWatchUrl(res);
+    const base64token = window.btoa(user.accessToken).replace(/=/g, '');
+    const socket = new WebSocket(watchUrl, [`base64url.bearer.authorization.k8s.io.${base64token}`, null]);
+
+    return Promise.resolve(new OpenShiftWatchEventListener(socket).init());
+  }
+
+  get(user, res, name) {
+    axios({
+      url: `${window.OPENSHIFT_CONFIG.masterUri}/apis/${res.group}/${res.version}/namespaces/${res.namespace}/${res.name}/${name}`,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+}

--- a/src/services/crmanagers/OpenShiftWatchEvents.js
+++ b/src/services/crmanagers/OpenShiftWatchEvents.js
@@ -1,0 +1,9 @@
+const OpenShiftWatchEvents = Object.freeze({
+  MODIFIED: 'MODIFIED',
+  ADDED: 'ADDED',
+  DELETED: 'DELETED',
+  OPENED: 'OPENED',
+  CLOSED: 'CLOSED'
+});
+
+export { OpenShiftWatchEvents }

--- a/src/services/crmanagers/OpenshiftResourceManagerFactory.js
+++ b/src/services/crmanagers/OpenshiftResourceManagerFactory.js
@@ -1,0 +1,27 @@
+import { GenericResourceManager } from './GenericResourceManager';
+import { PushVariantResourceManager } from './PushVariantResourceManager';
+import { getUser } from '../openshift';
+
+class UserBoundResourceManager {
+  constructor(resourceManager) {
+    this._resourceManager = resourceManager;
+  }
+
+  create = (res, obj, owner) => getUser().then(user => this._resourceManager.create(user, res, obj, owner));
+  remove = (res, obj) => getUser().then(user => this._resourceManager.remove(user, res, obj));
+  update = (res, obj) => getUser().then(user => this._resourceManager.update(user, res, obj));
+  list = (res, labels) => getUser().then(user => this._resourceManager.list(user, res, labels));
+  watch = res => getUser().then(user => this._resourceManager.watch(user, res));
+  get = (res, name) => getUser().then(user => this._resourceManager.get(user, res, name));
+}
+
+export class OpenshiftResourceManagerFactory {
+  static forResource(kind) {
+    switch (kind) {
+      case 'pushvariantcr':
+        return new UserBoundResourceManager(new PushVariantResourceManager());
+      default:
+        return new UserBoundResourceManager(new GenericResourceManager());
+    }
+  }
+}

--- a/src/services/crmanagers/PushVariantResourceManager.js
+++ b/src/services/crmanagers/PushVariantResourceManager.js
@@ -1,0 +1,8 @@
+import { GenericResourceManager } from './GenericResourceManager';
+
+export class PushVariantResourceManager extends GenericResourceManager {
+  create(res, obj, owner) {
+    // TODO: Add code to check if an application already exists and to create it if it doesn't.
+    return super.create(res, obj, owner);
+  }
+}

--- a/src/services/crmanagers/index.js
+++ b/src/services/crmanagers/index.js
@@ -1,0 +1,4 @@
+import { OpenshiftResourceManagerFactory } from './OpenshiftResourceManagerFactory';
+import { OpenShiftWatchEvents } from './OpenShiftWatchEvents';
+
+export { OpenshiftResourceManagerFactory, OpenShiftWatchEvents };

--- a/src/services/openshift.js
+++ b/src/services/openshift.js
@@ -1,43 +1,4 @@
-import axios from 'axios';
-import { map } from 'lodash-es';
-
-const OpenShiftWatchEvents = Object.freeze({
-  MODIFIED: 'MODIFIED',
-  ADDED: 'ADDED',
-  DELETED: 'DELETED',
-  OPENED: 'OPENED',
-  CLOSED: 'CLOSED'
-});
-
-class OpenShiftWatchEventListener {
-  _handler = () => {};
-  _errorHandler = () => {};
-
-  constructor(socket) {
-    this._socket = socket;
-  }
-
-  init() {
-    this._socket.onmessage = event => {
-      const data = JSON.parse(event.data);
-      this._handler({ type: data.type, payload: data.object });
-    };
-    this._socket.oncreate = () => this._handler({ type: OpenShiftWatchEvents.OPENED });
-    this._socket.onclose = () => this._handler({ type: OpenShiftWatchEvents.CLOSED });
-    this._socket.onerror = err => this._errorHandler(err);
-    return this;
-  }
-
-  onEvent(handler) {
-    this._handler = handler;
-    return this;
-  }
-
-  catch(handler) {
-    this._errorHandler = handler;
-    return this;
-  }
-}
+import { OpenshiftResourceManagerFactory, OpenShiftWatchEvents } from './crmanagers';
 
 const getNamespace = () => {
   if (window && window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.mdcNamespace) {
@@ -60,143 +21,20 @@ const getUser = () => {
   return Promise.reject(new Error('no user found'));
 };
 
-const get = (res, name) =>
-  getUser().then(user =>
-    axios({
-      url: `${window.OPENSHIFT_CONFIG.masterUri}/apis/${res.group}/${res.version}/namespaces/${res.namespace}/${res.name}/${name}`,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data)
-  );
+const get = (res, name) => OpenshiftResourceManagerFactory.forResource(res.kind).get(res, name);
 
-const update = (res, obj) =>
-  getUser().then(user => {
-    const requestUrl = _buildRequestUrl(res);
+const update = (res, obj) => OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).update(res, obj);
 
-    if (!obj.apiVersion) {
-      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
-    }
-
-    return axios({
-      url: `${requestUrl}/${obj.metadata.name}`,
-      method: 'PUT',
-      data: obj,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
-
-const list = res =>
-  getUser().then(user =>
-    axios({
-      url: _buildRequestUrl(res),
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data)
-  );
+const list = res => OpenshiftResourceManagerFactory.forResource(res.kind).list(res);
 
 const create = (res, obj, owner) =>
-  getUser().then(user => {
-    const requestUrl = _buildRequestUrl(res);
+  OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).create(res, obj, owner);
 
-    if (!obj.apiVersion) {
-      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
-    }
-    if (!obj.kind && res.kind) {
-      obj.kind = res.kind;
-    }
-    if (owner) {
-      obj.metadata.ownerReferences = [
-        {
-          apiVersion: owner.apiVersion,
-          kind: owner.kind,
-          blockOwnerDeletion: false,
-          name: owner.metadata.name,
-          uid: owner.metadata.uid
-        }
-      ];
-    }
+const remove = (res, obj) => OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).remove(res, obj);
 
-    return axios({
-      url: requestUrl,
-      method: 'POST',
-      data: obj,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
+const watch = res => OpenshiftResourceManagerFactory.forResource(res.kind).watch(res);
 
-const remove = (res, obj) =>
-  getUser().then(user => {
-    const requestUrl = _buildRequestUrl(res);
-
-    if (!obj.apiVersion) {
-      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
-    }
-    if (!obj.kind && res.kind) {
-      obj.kind = res.kind;
-    }
-
-    return axios({
-      url: `${requestUrl}/${obj.metadata.name}`,
-      method: 'DELETE',
-      data: {
-        apiVersion: obj.apiVersion,
-        kind: 'DeleteOptions',
-        propogationPolicy: 'Foreground'
-      },
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
-
-const watch = res =>
-  getUser().then(user => {
-    const watchUrl = _buildWatchUrl(res);
-    const base64token = window.btoa(user.accessToken).replace(/=/g, '');
-    const socket = new WebSocket(watchUrl, [`base64url.bearer.authorization.k8s.io.${base64token}`, null]);
-
-    return Promise.resolve(new OpenShiftWatchEventListener(socket).init());
-  });
-
-const listWithLabels = (res, labels) => {
-  let reqUrl = _buildRequestUrl(res);
-  if (labels) {
-    reqUrl = `${reqUrl}?labelSelector=${_labelsToQuery(labels)}`;
-  }
-  return getUser().then(user => {
-    axios({
-      url: reqUrl,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
-};
-
-const _buildOpenshiftApiUrl = (baseUrl, res) => (res.group ? `${baseUrl}/apis/${res.group}` : `${baseUrl}/api`);
-
-const _buildOpenShiftUrl = (baseUrl, res) => {
-  const urlBegin = `${_buildOpenshiftApiUrl(baseUrl, res)}/${res.version}`;
-  if (res.namespace) {
-    return `${urlBegin}/namespaces/${res.namespace}/${res.name}`;
-  }
-  return `${urlBegin}/${res.name}`;
-};
-
-const _buildRequestUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.masterUri, res)}`;
-
-const _buildWatchUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.wssMasterUri, res)}?watch=true`;
-
-const _labelsToQuery = labels => {
-  const labelsArr = map(labels, (value, name) => `${name}%3D${value}`);
-  return labelsArr.join(',');
-};
+const listWithLabels = (res, labels) => OpenshiftResourceManagerFactory.forResource(res.kind).list(res, labels);
 
 export {
   get,


### PR DESCRIPTION
## Motivation
The creation of a PushVariantCR is different than what we had until now: before we can create a variant, we have to check that an application already exists. It it doesn't it must be created. Then the new variant must be bound to this application.

## What
Added a resource manager factory so that a different resource manager can be returned for different resources. It defaults to the GenericResourceManager whose behaviour is the one we had until now.

## Verification Steps
Add the steps required to check this change. Following an example.
 
## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

