### PR TITLE
feat: added MSS icon to card when bound

### DIFF
--- a/src/components/overview/MobileClientCardViewItem.js
+++ b/src/components/overview/MobileClientCardViewItem.js
@@ -10,7 +10,8 @@ const getServiceIcons = services => {
     keycloak: <img alt="Keycloak" className="icon" src="/img/keycloak.svg" />,
     push: <img alt="Push" className="icon" src="/img/push.svg" />,
     sync: <img alt="Sync" className="icon" src="/img/sync.svg" />,
-    'sync-app': <img alt="Sync" className="icon" src="/img/sync.svg" />
+    'sync-app': <img alt="Sync" className="icon" src="/img/sync.svg" />,
+    security: <img alt="Security" className="icon" src="/img/security.svg" />
   };
   return services.map((service, i) => (
     <span className="service-icon" key={i}>


### PR DESCRIPTION
Closes AEROGEAR-9479

## Motivation

https://issues.jboss.org/browse/AEROGEAR-9479

## What

Added the Mobile Security Service icon to the MobileClient card when the service is bound.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Make sure the Mobile Security Service is bound to an app.
2. On the home page the app card should show the security icon when it is bound.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 

