### PR TITLE
feat: display route to Mobile Security Service

### DIFF
--- a/server/mobile-services-info.js
+++ b/server/mobile-services-info.js
@@ -157,6 +157,8 @@ const MobileSecurityService = {
       .then(configmap => {
         if (configmap) {
           const sdkConfig = JSON.parse(configmap.data.SDKConfig);
+          const sdkConfigUrl = url.parse(sdkConfig.url);
+          sdkConfigUrl.pathname = '';
           return {
             id: configmap.metadata.uid,
             name: MOBILE_SECURITY_TYPE,

--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -64,7 +64,10 @@ class BoundServiceRow extends Component {
     let propertyFragment;
 
     const docUrl = this.props.service.getDocumentationUrl();
-    const serviceConfigurations = this.props.service.getConfiguration(this.props.appName);
+    const serviceConfigurations = this.props.service.getConfiguration(
+      this.props.appName,
+      this.props.configurationOptions
+    );
 
     if (docUrl) {
       documentationFragment = (

--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -10,13 +10,13 @@ export class MobileSecurityServiceAppCR extends CustomResource {
     return true;
   }
 
-  getConfiguration() {
-    const appId = this.get('data.appId');
+  // eslint-disable-next-line class-methods-use-this
+  getConfiguration(_, options) {
     return [
       {
-        type: 'string',
-        label: 'App ID',
-        value: appId
+        type: 'href',
+        label: 'Mobile Security Service URL',
+        value: options.url
       }
     ];
   }

--- a/src/models/mobileservices/mobileservice.js
+++ b/src/models/mobileservices/mobileservice.js
@@ -94,9 +94,9 @@ export class MobileService {
     return this.customResourceClass.newInstance(formdata);
   }
 
-  getConfiguration(appName) {
+  getConfiguration(appName, options) {
     const crs = this.getCustomResourcesForApp(appName);
-    const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.url)), []);
+    const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.url, options)), []);
     const uniqConfigs = uniqBy(configurations, config => config.label);
     return uniqConfigs;
   }


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9475

## What

Show the URL/route to the Mobile Security Service from the bound App Security Service row.

## Why

To meet acceptance criteria.

## How

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run MDC with MSS enabled:

```sh
OPENSHIFT_HOST=$(minishift ip):8443 NAMESPACE=mobile-console OPENSHIFT_USER_TOKEN=$(oc whoami -t) MSS_NAMESPACE=mobile-console MSS_NAMESPACE=mobile-security-service MSS_APPS_NAMESPACE=mobile-security-service-apps npm run start:server
```

2. Create an app in MDC.
3. Bind App Security to the mobile client.
4. View the App Security bound service row. It should have a link to the MSS with the title **Mobile Security Service URL**.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

![Screenshot from 2019-07-01 12-10-18](https://user-images.githubusercontent.com/11743717/60432097-5236dd00-9bf9-11e9-83b2-f885263b6831.png)
