### PR TITLE
feat: renamed App Security to Mobile Security

### DIFF
--- a/server/appServices.js
+++ b/server/appServices.js
@@ -7,14 +7,14 @@ const {
   IdentityManagementService,
   MetricsService,
   DataSyncService,
-  AppSecurityService
+  MobileSecurityService
 } = require('./mobile-services-info');
 
-const services = [PushService, IdentityManagementService, MetricsService, DataSyncService, AppSecurityService];
+const services = [PushService, IdentityManagementService, MetricsService, DataSyncService, MobileSecurityService];
 
 const KEYCLOAK_SECRET_SUFFIX = '-install-config';
 const DATASYNC_CONFIGMAP_SUFFIX = '-data-sync-binding';
-const APP_SECURITY_SUFFIX = '-security';
+const MOBILE_SECURITY_SUFFIX = '-security';
 
 function updateAll(namespace, kubeclient) {
   console.log('Check services for all apps');
@@ -96,7 +96,7 @@ function updateAppsAndWatch(namespace, kubeclient) {
     const mssConfigMapJsonStream = new JSONStream();
     mssConfigMapStream.pipe(mssConfigMapJsonStream);
     mssConfigMapJsonStream.on('data', event => {
-      if (event.object && event.object.metadata.name.endsWith(APP_SECURITY_SUFFIX)) {
+      if (event.object && event.object.metadata.name.endsWith(MOBILE_SECURITY_SUFFIX)) {
         updateAll(namespace, kubeclient);
       }
     });
@@ -139,9 +139,9 @@ function watchMobileSecurityServiceCR(namespace, kubeclient) {
 
   jsonStream.on('data', event => {
     if (event.type === 'ADDED') {
-      AppSecurityService.disabled = false;
+      MobileSecurityService.disabled = false;
     } else if (event.type === 'DELETED') {
-      AppSecurityService.disabled = true;
+      MobileSecurityService.disabled = true;
     }
   });
 }

--- a/server/mobile-services-info.js
+++ b/server/mobile-services-info.js
@@ -4,7 +4,7 @@ const PUSH_SERVIE_TYPE = 'push';
 const IDM_SERVICE_TYPE = 'keycloak';
 const METRICS_SERVICE_TYPE = 'metrics';
 const DATA_SYNC_TYPE = 'sync-app';
-const APP_SECURITY_TYPE = 'security';
+const MOBILE_SECURITY_TYPE = 'security';
 
 function decodeBase64(encoded) {
   const buff = Buffer.from(encoded, 'base64');
@@ -133,12 +133,12 @@ const DataSyncService = {
   }
 };
 
-const AppSecurityService = {
-  type: APP_SECURITY_TYPE,
-  name: 'App Security',
+const MobileSecurityService = {
+  type: MOBILE_SECURITY_TYPE,
+  name: 'Mobile Security',
   disabled: true, // disabled by default. Will become enabled based on MSS operator availability
   icon: '/img/security.svg',
-  description: 'Mobile App Security',
+  description: 'Mobile Security Service',
   bindCustomResource: {
     name: 'mobilesecurityserviceapps',
     namespace: 'mobile-security-service-apps',
@@ -159,8 +159,8 @@ const AppSecurityService = {
           const sdkConfig = JSON.parse(configmap.data.SDKConfig);
           return {
             id: configmap.metadata.uid,
-            name: APP_SECURITY_TYPE,
-            type: APP_SECURITY_TYPE,
+            name: MOBILE_SECURITY_TYPE,
+            type: MOBILE_SECURITY_TYPE,
             url: url.format(sdkConfig.url)
           };
         }
@@ -182,7 +182,7 @@ const MobileServicesMap = {
   [IDM_SERVICE_TYPE]: IdentityManagementService,
   [METRICS_SERVICE_TYPE]: MetricsService,
   [DATA_SYNC_TYPE]: DataSyncService,
-  [APP_SECURITY_TYPE]: AppSecurityService
+  [MOBILE_SECURITY_TYPE]: MobileSecurityService
 };
 
 module.exports = {
@@ -191,5 +191,5 @@ module.exports = {
   IdentityManagementService,
   DataSyncService,
   MetricsService,
-  AppSecurityService
+  MobileSecurityService
 };

--- a/server/server.js
+++ b/server/server.js
@@ -11,7 +11,7 @@ const {
   IdentityManagementService,
   DataSyncService,
   MobileServicesMap,
-  AppSecurityService
+  MobileSecurityService
 } = require('./mobile-services-info');
 const { updateAppsAndWatch, watchMobileSecurityService } = require('./appServices');
 const mobileClientCRD = require('./mobile-client-crd.json');
@@ -50,7 +50,7 @@ const DEFAULT_SERVICES = {
       type: DataSyncService.type
     },
     {
-      type: AppSecurityService.type
+      type: MobileSecurityService.type
     }
   ]
 };

--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -57,8 +57,8 @@ export class MobileSecurityServiceAppCR extends CustomResource {
         }
       },
       validationRules: {
-        APP_SECURITY_BINDING: {
-          comment: 'This is the set of rules that will be used to validate APP_SECURITY bindings',
+        MOBILE_SECURITY_BINDING: {
+          comment: 'This is the set of rules that will be used to validate MOBILE_SECURITY bindings',
           fields: {
             appConfig: {
               appId: {


### PR DESCRIPTION
## What

Renamed references of "App Security" to be "Mobile Security".

## Verification Steps
 
1. In the list of services for a mobile app, inspect visually that there is a service called "Mobile Security".

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

