### PR TITLE
fix: URL was not formatted

### DIFF
--- a/server/mobile-services-info.js
+++ b/server/mobile-services-info.js
@@ -157,13 +157,12 @@ const MobileSecurityService = {
       .then(configmap => {
         if (configmap) {
           const sdkConfig = JSON.parse(configmap.data.SDKConfig);
-          const sdkConfigUrl = url.parse(sdkConfig.url);
-          sdkConfigUrl.pathname = '';
+          const sdkConfigUrl = sdkConfig.url;
           return {
             id: configmap.metadata.uid,
             name: MOBILE_SECURITY_TYPE,
             type: MOBILE_SECURITY_TYPE,
-            url: url.format(sdkConfig.url)
+            url: sdkConfigUrl
           };
         }
         return null;


### PR DESCRIPTION
## Motivation

This was done previously but was accidentally changed during a merge conflict.

## What

Ensure that the Mobile Security Service URL does not have any leading slash.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Ensure Mobile Security Service is running as a service.
2. Create an app in MDC.
3. Bind the Mobile Security Service. 
4. In the Bound Service row, the Mobile Security Service URL should not have a trailing forward slash

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task