### PR TITLE
Aerogear 9539

### DIFF
--- a/src/components/build/create_build_config/Validations.js
+++ b/src/components/build/create_build_config/Validations.js
@@ -18,7 +18,13 @@ import {
   KEY_CR_BUILD_IOS_CREDENTIALS_PROFILE_PASSWORD,
   withPath
 } from '../Constants';
-import { VALIDATION_OK, validateNotEmpty, validateGitUrl, VALIDATION_ERROR } from '../../common/Validation';
+import {
+  VALIDATION_OK,
+  validateNotEmpty,
+  validateGitUrl,
+  VALIDATION_ERROR,
+  validateNameString
+} from '../../common/Validation';
 
 export const setWithValidation = (dispatcher, validation) => (key, value) =>
   dispatcher(key, value, validation(key, value));
@@ -62,7 +68,7 @@ export function checkMandatoryFields(state) {
 export function configValidation(key, value) {
   switch (key) {
     case KEY_CR_NAME:
-      return validateNotEmpty(value);
+      return validateNameString(value);
     default:
       return VALIDATION_OK;
   }

--- a/src/components/common/Validation.js
+++ b/src/components/common/Validation.js
@@ -12,3 +12,11 @@ export function validateNotEmpty(value) {
 export function validateGitUrl(value) {
   return value && isGitUrl(value) ? VALIDATION_OK : VALIDATION_ERROR;
 }
+
+export function validateNameString(value) {
+  return value && isValidName(value) ? VALIDATION_OK : VALIDATION_ERROR;
+}
+
+function isValidName(value) {
+  return value.match('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$');
+}

--- a/src/components/common/Validation.test.js
+++ b/src/components/common/Validation.test.js
@@ -1,0 +1,56 @@
+import { validateNotEmpty, validateGitUrl, validateNameString, VALIDATION_OK, VALIDATION_ERROR } from './Validation';
+
+const checkOk = 'success';
+const checkError = 'error';
+
+describe('validateNotEmpty', () => {
+  it('has valid length', () => {
+    expect(validateNotEmpty('pass')).toEqual(checkOk);
+  });
+
+  it('has not a valid length', () => {
+    expect(validateNotEmpty('')).toEqual(checkError);
+  });
+
+  it('has null length', () => {
+    expect(validateNotEmpty(null)).toEqual(checkError);
+  });
+});
+
+describe('validateGitUrl', () => {
+  it('has valid url', () => {
+    expect(validateGitUrl('http://test.git')).toEqual(checkOk);
+  });
+
+  it('has not a valid url', () => {
+    expect(validateGitUrl('')).toEqual(checkError);
+  });
+
+  it('has null length', () => {
+    expect(validateGitUrl(null)).toEqual(checkError);
+  });
+});
+
+describe('validateNameString', () => {
+  it('has valid url', () => {
+    expect(validateNameString('passname19')).toEqual(checkOk);
+  });
+
+  it('has not a valid url', () => {
+    expect(validateNameString('FailName!!')).toEqual(checkError);
+  });
+
+  it('has null length', () => {
+    expect(validateNameString(null)).toEqual(checkError);
+  });
+});
+
+describe('Check constants', () => {
+  it('VALIDATION_OK == success', () => {
+    expect(VALIDATION_OK).toEqual(checkOk);
+  });
+
+  it('VALIDATION_ERROR == error', () => {
+    expect(VALIDATION_ERROR).toEqual(checkError);
+  });
+});


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9539

## What
Added validation around "Create build config" name field.

## Why
To reduce the risk of a user getting a 422 response back from the server

## How
This was achieved by adding Regex checking of the "Create build config" name. This uses the same regex expression that checks the apps name on creation. 

## Verification Steps
1. Enable build tab by setting the ENABLE_BUILD_TAB environment variable to true when running MDC.
2. Open the Build tab and click Create build config.
3. Enter a value that should be invalid in the name field. For example - "hhh!!!!www.".
4. Fill out the rest of the form as normal.
5. You should see a red highlighting around the name field and the Create button should be inactive.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
![image](https://user-images.githubusercontent.com/10224565/60579926-02345380-9d7c-11e9-81a5-b0684390e18b.png)

