### PR TITLE
UPS Operator integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4729,8 +4729,7 @@
     "@types/d3-color": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.2.tgz",
-      "integrity": "sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw==",
-      "optional": true
+      "integrity": "sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw=="
     },
     "@types/d3-dispatch": {
       "version": "1.0.7",
@@ -4750,8 +4749,7 @@
     "@types/d3-dsv": {
       "version": "1.0.36",
       "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.36.tgz",
-      "integrity": "sha512-jbIWQ27QJcBNMZbQv0NSQMHnBDCmxghAxePxgyiPH1XPCRkOsTBei7jcdi3fDrUCGpCV3lKrSZFSlOkhUQVClA==",
-      "optional": true
+      "integrity": "sha512-jbIWQ27QJcBNMZbQv0NSQMHnBDCmxghAxePxgyiPH1XPCRkOsTBei7jcdi3fDrUCGpCV3lKrSZFSlOkhUQVClA=="
     },
     "@types/d3-ease": {
       "version": "1.0.8",
@@ -4790,7 +4788,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.3.1.tgz",
       "integrity": "sha512-z8Zmi08XVwe8e62vP6wcA+CNuRhpuUU5XPEfqpG0hRypDE5BWNthQHB1UNWWDB7ojCbGaN4qBdsWp5kWxhT1IQ==",
-      "optional": true,
       "requires": {
         "@types/d3-color": "*"
       }
@@ -4798,8 +4795,7 @@
     "@types/d3-path": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.8.tgz",
-      "integrity": "sha512-AZGHWslq/oApTAHu9+yH/Bnk63y9oFOMROtqPAtxl5uB6qm1x2lueWdVEjsjjV3Qc2+QfuzKIwIR5MvVBakfzA==",
-      "optional": true
+      "integrity": "sha512-AZGHWslq/oApTAHu9+yH/Bnk63y9oFOMROtqPAtxl5uB6qm1x2lueWdVEjsjjV3Qc2+QfuzKIwIR5MvVBakfzA=="
     },
     "@types/d3-polygon": {
       "version": "1.0.7",
@@ -4846,8 +4842,7 @@
     "@types/d3-selection": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.1.tgz",
-      "integrity": "sha512-bv8IfFYo/xG6dxri9OwDnK3yCagYPeRIjTlrcdYJSx+FDWlCeBDepIHUpqROmhPtZ53jyna0aUajZRk0I3rXNA==",
-      "optional": true
+      "integrity": "sha512-bv8IfFYo/xG6dxri9OwDnK3yCagYPeRIjTlrcdYJSx+FDWlCeBDepIHUpqROmhPtZ53jyna0aUajZRk0I3rXNA=="
     },
     "@types/d3-shape": {
       "version": "1.3.1",
@@ -4861,8 +4856,7 @@
     "@types/d3-time": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.10.tgz",
-      "integrity": "sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw==",
-      "optional": true
+      "integrity": "sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw=="
     },
     "@types/d3-time-format": {
       "version": "2.1.1",
@@ -8315,7 +8309,6 @@
       "version": "1.10.19",
       "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.19.tgz",
       "integrity": "sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==",
-      "optional": true,
       "requires": {
         "jquery": ">=1.7"
       }
@@ -10416,8 +10409,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10435,13 +10427,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10454,18 +10444,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10568,8 +10555,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10579,7 +10565,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10592,20 +10577,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10622,7 +10604,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10695,8 +10676,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10706,7 +10686,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10782,8 +10761,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10813,7 +10791,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10831,7 +10808,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10870,13 +10846,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -21858,8 +21832,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -21877,13 +21850,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -21896,18 +21867,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -22010,8 +21978,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -22021,7 +21988,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -22034,20 +22000,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -22064,7 +22027,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -22137,8 +22099,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -22148,7 +22109,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -22224,8 +22184,7 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -22255,7 +22214,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -22273,7 +22231,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -22312,13 +22269,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/server/appServices.js
+++ b/server/appServices.js
@@ -15,6 +15,7 @@ const services = [PushService, IdentityManagementService, MetricsService, DataSy
 const KEYCLOAK_SECRET_SUFFIX = '-install-config';
 const DATASYNC_CONFIGMAP_SUFFIX = '-data-sync-binding';
 const MOBILE_SECURITY_SUFFIX = '-security';
+const UPS_SUFFIX = '-ups-variant';
 
 function updateAll(namespace, kubeclient) {
   console.log('Check services for all apps');
@@ -99,6 +100,15 @@ function updateAppsAndWatch(namespace, kubeclient) {
     mssConfigMapStream.pipe(mssConfigMapJsonStream);
     mssConfigMapJsonStream.on('data', event => {
       if (event.object && event.object.metadata.name.endsWith(MOBILE_SECURITY_SUFFIX)) {
+        updateAll(namespace, kubeclient);
+      }
+    });
+
+    const upsConfigMapStream = kubeclient.api.v1.watch.namespace(namespace).configmaps.getStream();
+    const upsConfigMapJsonStream = new JSONStream();
+    upsConfigMapStream.pipe(upsConfigMapJsonStream);
+    upsConfigMapJsonStream.on('data', event => {
+      if (event.object && event.object.metadata.name.endsWith(UPS_SUFFIX)) {
         updateAll(namespace, kubeclient);
       }
     });

--- a/server/mobile-services-info.js
+++ b/server/mobile-services-info.js
@@ -16,8 +16,7 @@ const PushService = {
   name: 'Push Notification',
   icon: '/img/push.svg',
   description: 'Unified Push Server',
-  bindCustomResource:
-  {
+  bindCustomResource: {
     name: 'pushapplications',
     version: 'v1alpha1',
     group: 'push.aerogear.org',
@@ -27,7 +26,7 @@ const PushService = {
         name: 'androidvariants',
         version: 'v1alpha1',
         group: 'push.aerogear.org',
-        kind: 'AndroidVariant',
+        kind: 'AndroidVariant'
       },
       {
         name: 'iosvariants',
@@ -38,35 +37,8 @@ const PushService = {
     ]
   },
   getClientConfig: (namespace, appname, kubeclient) => {
-    const configmapName = `${appname}-ups`;
-
-    return kubeclient.api.v1
-      .namespaces(namespace)
-      .configmaps(configmapName)
-      .get()
-      .then(resp => resp.body)
-      .then(configmap => {
-        if (configmap) {
-          const sdkConfig = JSON.parse(configmap.data.SDKConfig);
-          return {
-            id: configmap.metadata.uid,
-            name: APP_SECURITY_TYPE,
-            type: APP_SECURITY_TYPE,
-            url: url.format(sdkConfig.url)
-          };
-        }
-        return null;
-      })
-      .catch(err => {
-        if (err && err.statusCode && err.statusCode === 404) {
-          console.info(`Can not find configmap ${configmapName}`);
-        } else {
-          console.warn(`Error when fetch configmap ${configmapName}`, err);
-        }
-        return null;
-      });
+    // TODO: to be implemented
   }
-
 };
 
 const IdentityManagementService = {

--- a/server/server.js
+++ b/server/server.js
@@ -159,6 +159,11 @@ async function initKubeClient() {
     const conf =
       process.env.NODE_ENV === 'production' ? Request.config.getInCluster() : Request.config.fromKubeconfig();
     const backend = new Request(conf);
+
+    if (process.env.INSECURE_SERVER) {
+      backend.requestOptions.strictSSL = false;
+    }
+
     const kubeclient = new Client({ backend });
     await kubeclient.loadSpec();
     kubeclient.addCustomResourceDefinition(mobileClientCRD);

--- a/server/server.js
+++ b/server/server.js
@@ -162,7 +162,7 @@ async function initKubeClient() {
     backend.requestOptions.insecureSkipTlsVerify = true;
     backend.requestOptions.strictSSL = false;
 
-    const kubeclient = new Client({ backend, config: {insecureSkipTlsVerify: true } });
+    const kubeclient = new Client({ backend, config: { insecureSkipTlsVerify: true } });
     await kubeclient.loadSpec();
     kubeclient.addCustomResourceDefinition(mobileClientCRD);
     kubeclient.addCustomResourceDefinition(mobileSecurityServiceCRD);

--- a/server/server.js
+++ b/server/server.js
@@ -11,7 +11,8 @@ const {
   IdentityManagementService,
   DataSyncService,
   MobileServicesMap,
-  MobileSecurityService
+  MobileSecurityService,
+  PushService
 } = require('./mobile-services-info');
 const { updateAppsAndWatch, watchMobileSecurityService } = require('./appServices');
 const mobileClientCRD = require('./mobile-client-crd.json');
@@ -38,10 +39,10 @@ const DEFAULT_SERVICES = {
       type: IdentityManagementService.type,
       url: `https://${process.env.IDM_URL || process.env.OPENSHIFT_HOST}`
     },
-    // {
-    //   type: PushService.type,
-    //   url: `https://${process.env.UPS_URL || process.env.OPENSHIFT_HOST}`
-    // },
+    {
+      type: PushService.type,
+      url: `https://${process.env.UPS_URL || process.env.OPENSHIFT_HOST}`
+    },
     // {
     //   type: MetricsService.type,
     //   url: `https://${process.env.METRICS_URL || process.env.OPENSHIFT_HOST}`
@@ -158,7 +159,10 @@ async function initKubeClient() {
     const conf =
       process.env.NODE_ENV === 'production' ? Request.config.getInCluster() : Request.config.fromKubeconfig();
     const backend = new Request(conf);
-    const kubeclient = new Client({ backend });
+    backend.requestOptions.insecureSkipTlsVerify = true;
+    backend.requestOptions.strictSSL = false;
+
+    const kubeclient = new Client({ backend, config: {insecureSkipTlsVerify: true } });
     await kubeclient.loadSpec();
     kubeclient.addCustomResourceDefinition(mobileClientCRD);
     kubeclient.addCustomResourceDefinition(mobileSecurityServiceCRD);

--- a/server/server.js
+++ b/server/server.js
@@ -159,10 +159,7 @@ async function initKubeClient() {
     const conf =
       process.env.NODE_ENV === 'production' ? Request.config.getInCluster() : Request.config.fromKubeconfig();
     const backend = new Request(conf);
-    backend.requestOptions.insecureSkipTlsVerify = true;
-    backend.requestOptions.strictSSL = false;
-
-    const kubeclient = new Client({ backend, config: { insecureSkipTlsVerify: true } });
+    const kubeclient = new Client({ backend });
     await kubeclient.loadSpec();
     kubeclient.addCustomResourceDefinition(mobileClientCRD);
     kubeclient.addCustomResourceDefinition(mobileSecurityServiceCRD);

--- a/src/actions/services.js
+++ b/src/actions/services.js
@@ -80,10 +80,7 @@ export const deleteCustomResource = (service, cr) => async dispatch => {
 function listCustomResourceForService(dispatch, service) {
   const custRes = service.bindCustomResource;
   custRes.namespace = service.bindCustomResource.namespace || getNamespace();
-
-  const listRes = list(custRes);
-
-  return listRes
+  return list(custRes)
     .then(resList => {
       const { items } = resList;
       dispatch({ type: CUSTOM_RESOURCE_LIST_SUCCESS, service, resource: custRes, items });

--- a/src/actions/services.js
+++ b/src/actions/services.js
@@ -80,7 +80,10 @@ export const deleteCustomResource = (service, cr) => async dispatch => {
 function listCustomResourceForService(dispatch, service) {
   const custRes = service.bindCustomResource;
   custRes.namespace = service.bindCustomResource.namespace || getNamespace();
-  return list(custRes)
+
+  const listRes = list(custRes);
+
+  return listRes
     .then(resList => {
       const { items } = resList;
       dispatch({ type: CUSTOM_RESOURCE_LIST_SUCCESS, service, resource: custRes, items });

--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { ListViewItem, Row, Col, DropdownKebab } from 'patternfly-react';
-import { get as _get } from 'lodash-es';
+import { filter as _filter, get as _get } from 'lodash-es';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
 import DeleteItemButton from '../../containers/DeleteItemButton';
@@ -129,19 +129,14 @@ class BoundServiceRow extends Component {
     if (!this.props.service.isUPSService()) {
       return null;
     }
-    const configurationExt = this.props.service.getConfigurationExtAsJSON();
-    // sample value for configurationExt
-    /*
-      [
-        {"type":"ios","typeLabel":"iOS","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/c8d70b96-bd52-499c-845b-756089e06d36","id":"c8d70b96-bd52-499c-845b-756089e06d36"},
-        {"type":"android","typeLabel":"Android","url":"https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f","id":"2d76d1eb-65ef-471c-8d21-75f80c3f370f"}
-      ]
-    */
-    if (configurationExt && configurationExt.length) {
-      if (configurationExt[0] && configurationExt[0].length && configurationExt[0].length >= 2) {
-        // there are 2 variants already. can't create another variant.
-        return null;
-      }
+
+    const binds = _filter(
+      this.props.service.customResources,
+      res => res.data.metadata.labels && res.data.metadata.labels['mobile.aerogear.org/client'] === this.props.appName
+    );
+
+    if (binds.length >= 2) {
+      return null;
     }
 
     return <BindButton service={this.props.service} onClick={this.props.onCreateBinding} />;

--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { ListViewItem, Row, Col, DropdownKebab } from 'patternfly-react';
-import { filter as _filter, get as _get } from 'lodash-es';
+import { get as _get } from 'lodash-es';
 import '../configuration/ServiceSDKInfo.css';
 import './ServiceRow.css';
 import DeleteItemButton from '../../containers/DeleteItemButton';
@@ -130,12 +130,7 @@ class BoundServiceRow extends Component {
       return null;
     }
 
-    const binds = _filter(
-      this.props.service.customResources,
-      res => res.data.metadata.labels && res.data.metadata.labels['mobile.aerogear.org/client'] === this.props.appName
-    );
-
-    if (binds.length >= 2) {
+    if (this.props.service.getCustomResourcesForApp(this.props.appName).length >= 2) {
       return null;
     }
 

--- a/src/components/mobileservices/BoundServiceRow.test.js
+++ b/src/components/mobileservices/BoundServiceRow.test.js
@@ -147,15 +147,15 @@ describe('BoundServiceRow - UPS - 2 bindings', () => {
     getConfigurationExtAsJSON: () => [
       [
         {
-          type: 'android',
-          typeLabel: 'Android',
+          type: 'AndroidVariant',
+          typeLabel: 'AndroidVariant',
           url:
             'https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/2d76d1eb-65ef-471c-8d21-75f80c3f370f',
           id: '2d76d1eb-65ef-471c-8d21-75f80c3f370f'
         },
         {
-          type: 'ios',
-          typeLabel: 'iOS',
+          type: 'IOSVariant',
+          typeLabel: 'IOSVariant',
           url:
             'https://ups-mdc.127.0.0.1.nip.io/#/app/8936dead-7552-4b55-905c-926752c759af/variants/c8d70b96-bd52-499c-845b-756089e06d36',
           id: 'c8d70b96-bd52-499c-845b-756089e06d36'
@@ -177,8 +177,12 @@ describe('BoundServiceRow - UPS - 2 bindings', () => {
     isBound: () => true,
     getCustomResourcesForApp: () => [
       {
-        getName: () => 'test-ups-r66b9',
+        getName: () => 'test-ups-r66b9-android',
         getPlatform: () => 'android'
+      },
+      {
+        getName: () => 'test-ups-r66b9-ios',
+        getPlatform: () => 'ios'
       }
     ]
   };

--- a/src/models/mobileservices/customresourcefactory.js
+++ b/src/models/mobileservices/customresourcefactory.js
@@ -37,7 +37,6 @@ export function newCustomResourceClass(serviceInfo) {
   if (serviceInfo.type === 'sync-app') {
     return DataSyncCR;
   }
-  // TODO: use the right kind
   if (serviceInfo.type === 'push') {
     return PushVariantCR;
   }

--- a/src/models/mobileservices/pushapplicationcr.js
+++ b/src/models/mobileservices/pushapplicationcr.js
@@ -1,0 +1,35 @@
+import { CustomResource } from './customresource';
+
+export class PushApplicationCR extends CustomResource {
+  constructor(data = {}) {
+    super(data);
+  }
+
+  getPlatform() {
+    // TODO: fix me!!
+    return this.spec.get('platform');
+  }
+
+  getConfiguration(serviceHost) {}
+
+  static bindForm(params) {}
+
+  static newInstance(params) {
+    const { name } = params;
+
+    return {
+      apiVersion: 'push.aerogear.org/v1alpha1',
+      kind: 'PushApplication',
+      metadata: {
+        name
+      },
+      spec: {
+        description: 'MDC Push Application'
+      }
+    };
+  }
+
+  static getDocumentationUrl() {
+    return 'https://docs.aerogear.org/external/apb/unifiedpush.html';
+  }
+}

--- a/src/models/mobileservices/pushapplicationcr.js
+++ b/src/models/mobileservices/pushapplicationcr.js
@@ -10,6 +10,7 @@ export class PushApplicationCR extends CustomResource {
     return this.spec.get('platform');
   }
 
+  // eslint-disable-next-line class-methods-use-this
   getConfiguration(serviceHost) {}
 
   static bindForm(params) {}
@@ -31,5 +32,10 @@ export class PushApplicationCR extends CustomResource {
 
   static getDocumentationUrl() {
     return 'https://docs.aerogear.org/external/apb/unifiedpush.html';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  isReady() {
+    return true;
   }
 }

--- a/src/models/mobileservices/pushvariantcr.js
+++ b/src/models/mobileservices/pushvariantcr.js
@@ -32,6 +32,10 @@ export class PushVariantCR extends CustomResource {
     ];
   }
 
+  isReady() {
+    return true;
+  }
+
   static bindForm(params) {
     const { service } = params;
     const hasIOS = hasPlatform(service, 'ios');
@@ -224,8 +228,47 @@ export class PushVariantCR extends CustomResource {
   }
 
   static newInstance(params) {
-    // TODO: implement me!
-    return {};
+    const { CLIENT_ID, CLIENT_TYPE } = params;
+
+    switch(CLIENT_TYPE) {
+      case 'Android':
+        return {
+          apiVersion: 'push.aerogear.org/v1alpha1',
+          kind: 'AndroidVariant',
+          metadata: {
+            name: `${CLIENT_ID}-ups-android`,
+            labels: {
+              'mobile.aerogear.org/client': CLIENT_ID
+            }
+          },
+          spec: {
+            description: 'UPS Android Variant',
+            serverKey: params.platformConfig.googlekey,
+            senderId: '',
+            pushApplicationId: null
+          }
+        };
+      case 'iOS':
+        return {
+          apiVersion: 'push.aerogear.org/v1alpha1',
+          kind: 'IOSVariant',
+          metadata: {
+            name: `${CLIENT_ID}-ups-ios`,
+            labels: {
+              'mobile.aerogear.org/client': CLIENT_ID
+            }
+          },
+          spec: {
+            description: 'UPS iOS Variant',
+            certificate: params.platformConfig.cert,
+            passphrase: params.platformConfig.passphrase,
+            production: params.platformConfig.iosIsProduction,
+            pushApplicationId: null
+          }
+        };
+      default:
+        return {};
+    }
   }
 
   static getDocumentationUrl() {

--- a/src/models/mobileservices/pushvariantcr.js
+++ b/src/models/mobileservices/pushvariantcr.js
@@ -39,6 +39,10 @@ export class PushVariantCR extends CustomResource {
     return true;
   }
 
+  isInProgress() {
+    return !this.status || !this.status.data.ready;
+  }
+
   static bindForm(params) {
     const { service } = params;
     const hasIOS = hasPlatform(service, params.appName, 'IOSVariant');

--- a/src/services/crmanagers/GenericResourceManager.js
+++ b/src/services/crmanagers/GenericResourceManager.js
@@ -1,0 +1,158 @@
+import { map } from 'lodash-es';
+import axios from 'axios';
+import { OpenShiftWatchEvents } from './OpenShiftWatchEvents';
+
+const _buildOpenshiftApiUrl = (baseUrl, res) => (res.group ? `${baseUrl}/apis/${res.group}` : `${baseUrl}/api`);
+
+const _buildOpenShiftUrl = (baseUrl, res) => {
+  const urlBegin = `${_buildOpenshiftApiUrl(baseUrl, res)}/${res.version}`;
+  if (res.namespace) {
+    return `${urlBegin}/namespaces/${res.namespace}/${res.name}`;
+  }
+  return `${urlBegin}/${res.name}`;
+};
+
+const _buildRequestUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.masterUri, res)}`;
+
+const _buildWatchUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.wssMasterUri, res)}?watch=true`;
+
+const _labelsToQuery = labels => {
+  const labelsArr = map(labels, (value, name) => `${name}%3D${value}`);
+  return labelsArr.join(',');
+};
+
+class OpenShiftWatchEventListener {
+  _handler = () => {};
+  _errorHandler = () => {};
+
+  constructor(socket) {
+    this._socket = socket;
+  }
+
+  init() {
+    this._socket.onmessage = event => {
+      const data = JSON.parse(event.data);
+      this._handler({ type: data.type, payload: data.object });
+    };
+    this._socket.oncreate = () => this._handler({ type: OpenShiftWatchEvents.OPENED });
+    this._socket.onclose = () => this._handler({ type: OpenShiftWatchEvents.CLOSED });
+    this._socket.onerror = err => this._errorHandler(err);
+    return this;
+  }
+
+  onEvent(handler) {
+    this._handler = handler;
+    return this;
+  }
+
+  catch(handler) {
+    this._errorHandler = handler;
+    return this;
+  }
+}
+
+/* eslint-disable class-methods-use-this */
+
+export class GenericResourceManager {
+  create(user, res, obj, owner) {
+    const requestUrl = _buildRequestUrl(res);
+
+    if (!obj.apiVersion) {
+      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
+    }
+    if (!obj.kind && res.kind) {
+      obj.kind = res.kind;
+    }
+    if (owner) {
+      obj.metadata.ownerReferences = [
+        {
+          apiVersion: owner.apiVersion,
+          kind: owner.kind,
+          blockOwnerDeletion: false,
+          name: owner.metadata.name,
+          uid: owner.metadata.uid
+        }
+      ];
+    }
+
+    return axios({
+      url: requestUrl,
+      method: 'POST',
+      data: obj,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  remove(user, res, obj) {
+    const requestUrl = _buildRequestUrl(res);
+
+    if (!obj.apiVersion) {
+      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
+    }
+    if (!obj.kind && res.kind) {
+      obj.kind = res.kind;
+    }
+
+    return axios({
+      url: `${requestUrl}/${obj.metadata.name}`,
+      method: 'DELETE',
+      data: {
+        apiVersion: obj.apiVersion,
+        kind: 'DeleteOptions',
+        propogationPolicy: 'Foreground'
+      },
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  update(user, res, obj) {
+    const requestUrl = _buildRequestUrl(res);
+
+    if (!obj.apiVersion) {
+      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
+    }
+
+    return axios({
+      url: `${requestUrl}/${obj.metadata.name}`,
+      method: 'PUT',
+      data: obj,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  list(user, res, labels) {
+    let reqUrl = _buildRequestUrl(res);
+    if (labels) {
+      reqUrl = `${reqUrl}?labelSelector=${_labelsToQuery(labels)}`;
+    }
+    return axios({
+      url: reqUrl,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+
+  watch(user, res) {
+    const watchUrl = _buildWatchUrl(res);
+    const base64token = window.btoa(user.accessToken).replace(/=/g, '');
+    const socket = new WebSocket(watchUrl, [`base64url.bearer.authorization.k8s.io.${base64token}`, null]);
+
+    return Promise.resolve(new OpenShiftWatchEventListener(socket).init());
+  }
+
+  get(user, res, name) {
+    axios({
+      url: `${window.OPENSHIFT_CONFIG.masterUri}/apis/${res.group}/${res.version}/namespaces/${res.namespace}/${res.name}/${name}`,
+      headers: {
+        authorization: `Bearer ${user.accessToken}`
+      }
+    }).then(response => response.data);
+  }
+}

--- a/src/services/crmanagers/GenericResourceManager.js
+++ b/src/services/crmanagers/GenericResourceManager.js
@@ -35,6 +35,11 @@ class OpenShiftWatchEventListener {
 
 /* eslint-disable class-methods-use-this */
 
+/**
+ * This class has all the method to be used for common operation on the resources.
+ * If a resource needs some custom operation, a dedicated resource manager instance extending
+ * this class should be provided.
+ */
 export class GenericResourceManager {
   create(user, res, obj, owner) {
     const requestUrl = _buildRequestUrl(res);

--- a/src/services/crmanagers/GenericResourceManager.js
+++ b/src/services/crmanagers/GenericResourceManager.js
@@ -1,25 +1,7 @@
-import { map } from 'lodash-es';
 import axios from 'axios';
 import { OpenShiftWatchEvents } from './OpenShiftWatchEvents';
 
-const _buildOpenshiftApiUrl = (baseUrl, res) => (res.group ? `${baseUrl}/apis/${res.group}` : `${baseUrl}/api`);
-
-const _buildOpenShiftUrl = (baseUrl, res) => {
-  const urlBegin = `${_buildOpenshiftApiUrl(baseUrl, res)}/${res.version}`;
-  if (res.namespace) {
-    return `${urlBegin}/namespaces/${res.namespace}/${res.name}`;
-  }
-  return `${urlBegin}/${res.name}`;
-};
-
-const _buildRequestUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.masterUri, res)}`;
-
-const _buildWatchUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.wssMasterUri, res)}?watch=true`;
-
-const _labelsToQuery = labels => {
-  const labelsArr = map(labels, (value, name) => `${name}%3D${value}`);
-  return labelsArr.join(',');
-};
+import { _buildRequestUrl, _labelsToQuery, _buildWatchUrl } from './utils';
 
 class OpenShiftWatchEventListener {
   _handler = () => {};
@@ -148,7 +130,7 @@ export class GenericResourceManager {
   }
 
   get(user, res, name) {
-    axios({
+    return axios({
       url: `${window.OPENSHIFT_CONFIG.masterUri}/apis/${res.group}/${res.version}/namespaces/${res.namespace}/${res.name}/${name}`,
       headers: {
         authorization: `Bearer ${user.accessToken}`

--- a/src/services/crmanagers/OpenShiftWatchEvents.js
+++ b/src/services/crmanagers/OpenShiftWatchEvents.js
@@ -6,4 +6,4 @@ const OpenShiftWatchEvents = Object.freeze({
   CLOSED: 'CLOSED'
 });
 
-export { OpenShiftWatchEvents }
+export { OpenShiftWatchEvents };

--- a/src/services/crmanagers/OpenShiftWatchEvents.js
+++ b/src/services/crmanagers/OpenShiftWatchEvents.js
@@ -1,0 +1,9 @@
+const OpenShiftWatchEvents = Object.freeze({
+  MODIFIED: 'MODIFIED',
+  ADDED: 'ADDED',
+  DELETED: 'DELETED',
+  OPENED: 'OPENED',
+  CLOSED: 'CLOSED'
+});
+
+export { OpenShiftWatchEvents }

--- a/src/services/crmanagers/OpenshiftResourceManagerFactory.js
+++ b/src/services/crmanagers/OpenshiftResourceManagerFactory.js
@@ -1,0 +1,27 @@
+import { GenericResourceManager } from './GenericResourceManager';
+import { PushVariantResourceManager } from './PushVariantResourceManager';
+import { getUser } from '../openshift';
+
+class UserBoundResourceManager {
+  constructor(resourceManager) {
+    this._resourceManager = resourceManager;
+  }
+
+  create = (res, obj, owner) => getUser().then(user => this._resourceManager.create(user, res, obj, owner));
+  remove = (res, obj) => getUser().then(user => this._resourceManager.remove(user, res, obj));
+  update = (res, obj) => getUser().then(user => this._resourceManager.update(user, res, obj));
+  list = (res, labels) => getUser().then(user => this._resourceManager.list(user, res, labels));
+  watch = res => getUser().then(user => this._resourceManager.watch(user, res));
+  get = (res, name) => getUser().then(user => this._resourceManager.get(user, res, name));
+}
+
+export class OpenshiftResourceManagerFactory {
+  static forResource(kind) {
+    switch (kind) {
+      case 'pushvariantcr':
+        return new UserBoundResourceManager(new PushVariantResourceManager());
+      default:
+        return new UserBoundResourceManager(new GenericResourceManager());
+    }
+  }
+}

--- a/src/services/crmanagers/OpenshiftResourceManagerFactory.js
+++ b/src/services/crmanagers/OpenshiftResourceManagerFactory.js
@@ -18,7 +18,9 @@ class UserBoundResourceManager {
 export class OpenshiftResourceManagerFactory {
   static forResource(kind) {
     switch (kind) {
-      case 'pushvariantcr':
+      case 'pushapplications':
+      case 'AndroidVariant':
+      case 'IOSVariant':
         return new UserBoundResourceManager(new PushVariantResourceManager());
       default:
         return new UserBoundResourceManager(new GenericResourceManager());

--- a/src/services/crmanagers/PushVariantResourceManager.js
+++ b/src/services/crmanagers/PushVariantResourceManager.js
@@ -1,8 +1,84 @@
+import _ from 'lodash-es';
 import { GenericResourceManager } from './GenericResourceManager';
+import { PushApplicationCR } from '../../models/mobileservices/pushapplicationcr';
+
+function poll(fnToBePolled, checkOutcome, timeout, interval) {
+  const endTime = Number(new Date()) + (timeout || 2000);
+  interval = interval || 100;
+
+  const checkCondition = function(resolve, reject) {
+    const promise = fnToBePolled();
+
+    promise.then(data => {
+      const res = checkOutcome(data);
+
+      if (res) {
+        resolve(res);
+      } else if (Number(new Date()) < endTime) {
+        setTimeout(checkCondition, interval, resolve, reject);
+      } else {
+        reject(new Error('timed out for'));
+      }
+    });
+  };
+
+  return new Promise(checkCondition);
+}
 
 export class PushVariantResourceManager extends GenericResourceManager {
-  create(res, obj, owner) {
+  async create(user, res, variantData, mobileApp) {
     // TODO: Add code to check if an application already exists and to create it if it doesn't.
-    return super.create(res, obj, owner);
+    // super.list(user, res)
+
+    const apps = await super.list(user, res);
+    let app = _.find(apps.items, item => item.metadata.name === mobileApp.metadata.name);
+
+    if (!app) {
+      app = await super.create(
+        user,
+        {
+          name: 'pushapplications',
+          version: 'v1alpha1',
+          group: 'push.aerogear.org',
+          kind: 'pushapplications',
+          namespace: res.namespace
+        },
+        PushApplicationCR.newInstance({ name: mobileApp.metadata.name }),
+        mobileApp
+      );
+
+      app = await poll(
+        () => super.list(user, res),
+        appList => {
+          const foundApp = _.find(appList.items, item => item.metadata.name === mobileApp.metadata.name);
+          if (foundApp.status) return foundApp;
+          return null;
+        },
+        5000,
+        1000
+      );
+
+      console.log('Created ', app);
+    }
+
+    variantData.spec.pushApplicationId = app.status.pushApplicationId;
+
+    console.log('assign application id');
+
+    const variantCR = _.find(res.variants, item => item.kind === variantData.kind);
+    variantCR.namespace = res.namespace;
+
+    return super.create(user, variantCR, variantData, mobileApp);
+  }
+
+  list(user, res, labels) {
+    return Promise.all(res.variants.map(variantRes => super.list(user, variantRes, labels))).then(results => {
+      const result = results[0];
+      result.kind = 'Variants';
+      delete result.metadata;
+      result.items.push(...results[1].items);
+
+      return result;
+    });
   }
 }

--- a/src/services/crmanagers/PushVariantResourceManager.js
+++ b/src/services/crmanagers/PushVariantResourceManager.js
@@ -80,4 +80,8 @@ export class PushVariantResourceManager extends GenericResourceManager {
 
     return super.remove(user, variantCR, variantData);
   }
+
+  watch(user, res) {
+    return Promise.all(res.variants.map(variantRes => super.watch(user, variantRes)));
+  }
 }

--- a/src/services/crmanagers/PushVariantResourceManager.js
+++ b/src/services/crmanagers/PushVariantResourceManager.js
@@ -1,0 +1,8 @@
+import { GenericResourceManager } from './GenericResourceManager';
+
+export class PushVariantResourceManager extends GenericResourceManager {
+  create(res, obj, owner) {
+    // TODO: Add code to check if an application already exists and to create it if it doesn't.
+    return super.create(res, obj, owner);
+  }
+}

--- a/src/services/crmanagers/ResourceManagerFactory.js
+++ b/src/services/crmanagers/ResourceManagerFactory.js
@@ -2,6 +2,10 @@ import { GenericResourceManager } from './GenericResourceManager';
 import { PushVariantResourceManager } from './PushVariantResourceManager';
 import { getUser } from '../openshift';
 
+/**
+ * This class delegates all his operation to the provided resource manager.
+ * The added value of this layer is that it automatically passes the user object.
+ */
 class UserBoundResourceManager {
   constructor(resourceManager) {
     this._resourceManager = resourceManager;
@@ -15,7 +19,11 @@ class UserBoundResourceManager {
   get = (res, name) => getUser().then(user => this._resourceManager.get(user, res, name));
 }
 
-export class OpenshiftResourceManagerFactory {
+/**
+ * This class produces the resource manager for the received resource.
+ * The resource manager will automatically received the user object.
+ */
+export class ResourceManagerFactory {
   static forResource(kind) {
     switch (kind) {
       case 'pushapplications':

--- a/src/services/crmanagers/index.js
+++ b/src/services/crmanagers/index.js
@@ -1,0 +1,4 @@
+import { OpenshiftResourceManagerFactory } from './OpenshiftResourceManagerFactory';
+import { OpenShiftWatchEvents } from './OpenShiftWatchEvents';
+
+export { OpenshiftResourceManagerFactory, OpenShiftWatchEvents };

--- a/src/services/crmanagers/index.js
+++ b/src/services/crmanagers/index.js
@@ -1,4 +1,4 @@
-import { OpenshiftResourceManagerFactory } from './OpenshiftResourceManagerFactory';
+import { ResourceManagerFactory } from './ResourceManagerFactory';
 import { OpenShiftWatchEvents } from './OpenShiftWatchEvents';
 
-export { OpenshiftResourceManagerFactory, OpenShiftWatchEvents };
+export { ResourceManagerFactory, OpenShiftWatchEvents };

--- a/src/services/crmanagers/utils.js
+++ b/src/services/crmanagers/utils.js
@@ -1,0 +1,20 @@
+import { map } from 'lodash-es';
+
+export const _buildOpenshiftApiUrl = (baseUrl, res) => (res.group ? `${baseUrl}/apis/${res.group}` : `${baseUrl}/api`);
+
+export const _buildOpenShiftUrl = (baseUrl, res) => {
+  const urlBegin = `${_buildOpenshiftApiUrl(baseUrl, res)}/${res.version}`;
+  if (res.namespace) {
+    return `${urlBegin}/namespaces/${res.namespace}/${res.name}`;
+  }
+  return `${urlBegin}/${res.name}`;
+};
+
+export const _buildRequestUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.masterUri, res)}`;
+
+export const _buildWatchUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.wssMasterUri, res)}?watch=true`;
+
+export const _labelsToQuery = labels => {
+  const labelsArr = map(labels, (value, name) => `${name}%3D${value}`);
+  return labelsArr.join(',');
+};

--- a/src/services/openshift.js
+++ b/src/services/openshift.js
@@ -1,4 +1,4 @@
-import { OpenshiftResourceManagerFactory, OpenShiftWatchEvents } from './crmanagers';
+import { ResourceManagerFactory, OpenShiftWatchEvents } from './crmanagers';
 
 const getNamespace = () => {
   if (window && window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.mdcNamespace) {
@@ -21,20 +21,19 @@ const getUser = () => {
   return Promise.reject(new Error('no user found'));
 };
 
-const get = (res, name) => OpenshiftResourceManagerFactory.forResource(res.kind).get(res, name);
+const get = (res, name) => ResourceManagerFactory.forResource(res.kind).get(res, name);
 
-const update = (res, obj) => OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).update(res, obj);
+const update = (res, obj) => ResourceManagerFactory.forResource(obj.kind || res.kind).update(res, obj);
 
-const list = res => OpenshiftResourceManagerFactory.forResource(res.kind).list(res);
+const list = res => ResourceManagerFactory.forResource(res.kind).list(res);
 
-const create = (res, obj, owner) =>
-  OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).create(res, obj, owner);
+const create = (res, obj, owner) => ResourceManagerFactory.forResource(obj.kind || res.kind).create(res, obj, owner);
 
-const remove = (res, obj) => OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).remove(res, obj);
+const remove = (res, obj) => ResourceManagerFactory.forResource(obj.kind || res.kind).remove(res, obj);
 
-const watch = res => OpenshiftResourceManagerFactory.forResource(res.kind).watch(res);
+const watch = res => ResourceManagerFactory.forResource(res.kind).watch(res);
 
-const listWithLabels = (res, labels) => OpenshiftResourceManagerFactory.forResource(res.kind).list(res, labels);
+const listWithLabels = (res, labels) => ResourceManagerFactory.forResource(res.kind).list(res, labels);
 
 export {
   get,

--- a/src/services/openshift.js
+++ b/src/services/openshift.js
@@ -1,43 +1,4 @@
-import axios from 'axios';
-import { map } from 'lodash-es';
-
-const OpenShiftWatchEvents = Object.freeze({
-  MODIFIED: 'MODIFIED',
-  ADDED: 'ADDED',
-  DELETED: 'DELETED',
-  OPENED: 'OPENED',
-  CLOSED: 'CLOSED'
-});
-
-class OpenShiftWatchEventListener {
-  _handler = () => {};
-  _errorHandler = () => {};
-
-  constructor(socket) {
-    this._socket = socket;
-  }
-
-  init() {
-    this._socket.onmessage = event => {
-      const data = JSON.parse(event.data);
-      this._handler({ type: data.type, payload: data.object });
-    };
-    this._socket.oncreate = () => this._handler({ type: OpenShiftWatchEvents.OPENED });
-    this._socket.onclose = () => this._handler({ type: OpenShiftWatchEvents.CLOSED });
-    this._socket.onerror = err => this._errorHandler(err);
-    return this;
-  }
-
-  onEvent(handler) {
-    this._handler = handler;
-    return this;
-  }
-
-  catch(handler) {
-    this._errorHandler = handler;
-    return this;
-  }
-}
+import { OpenshiftResourceManagerFactory, OpenShiftWatchEvents } from './crmanagers';
 
 const getNamespace = () => {
   if (window && window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.mdcNamespace) {
@@ -60,143 +21,20 @@ const getUser = () => {
   return Promise.reject(new Error('no user found'));
 };
 
-const get = (res, name) =>
-  getUser().then(user =>
-    axios({
-      url: `${window.OPENSHIFT_CONFIG.masterUri}/apis/${res.group}/${res.version}/namespaces/${res.namespace}/${res.name}/${name}`,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data)
-  );
+const get = (res, name) => OpenshiftResourceManagerFactory.forResource(res.kind).get(res, name);
 
-const update = (res, obj) =>
-  getUser().then(user => {
-    const requestUrl = _buildRequestUrl(res);
+const update = (res, obj) => OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).update(res, obj);
 
-    if (!obj.apiVersion) {
-      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
-    }
-
-    return axios({
-      url: `${requestUrl}/${obj.metadata.name}`,
-      method: 'PUT',
-      data: obj,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
-
-const list = res =>
-  getUser().then(user =>
-    axios({
-      url: _buildRequestUrl(res),
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data)
-  );
+const list = res => OpenshiftResourceManagerFactory.forResource(res.kind).list(res);
 
 const create = (res, obj, owner) =>
-  getUser().then(user => {
-    const requestUrl = _buildRequestUrl(res);
+  OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).create(res, obj, owner);
 
-    if (!obj.apiVersion) {
-      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
-    }
-    if (!obj.kind && res.kind) {
-      obj.kind = res.kind;
-    }
-    if (owner) {
-      obj.metadata.ownerReferences = [
-        {
-          apiVersion: owner.apiVersion,
-          kind: owner.kind,
-          blockOwnerDeletion: false,
-          name: owner.metadata.name,
-          uid: owner.metadata.uid
-        }
-      ];
-    }
+const remove = (res, obj) => OpenshiftResourceManagerFactory.forResource(obj.kind || res.kind).remove(res, obj);
 
-    return axios({
-      url: requestUrl,
-      method: 'POST',
-      data: obj,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
+const watch = res => OpenshiftResourceManagerFactory.forResource(res.kind).watch(res);
 
-const remove = (res, obj) =>
-  getUser().then(user => {
-    const requestUrl = _buildRequestUrl(res);
-
-    if (!obj.apiVersion) {
-      obj.apiVersion = res.group ? `${res.group}/${res.version}` : res.version;
-    }
-    if (!obj.kind && res.kind) {
-      obj.kind = res.kind;
-    }
-
-    return axios({
-      url: `${requestUrl}/${obj.metadata.name}`,
-      method: 'DELETE',
-      data: {
-        apiVersion: obj.apiVersion,
-        kind: 'DeleteOptions',
-        propogationPolicy: 'Foreground'
-      },
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
-
-const watch = res =>
-  getUser().then(user => {
-    const watchUrl = _buildWatchUrl(res);
-    const base64token = window.btoa(user.accessToken).replace(/=/g, '');
-    const socket = new WebSocket(watchUrl, [`base64url.bearer.authorization.k8s.io.${base64token}`, null]);
-
-    return Promise.resolve(new OpenShiftWatchEventListener(socket).init());
-  });
-
-const listWithLabels = (res, labels) => {
-  let reqUrl = _buildRequestUrl(res);
-  if (labels) {
-    reqUrl = `${reqUrl}?labelSelector=${_labelsToQuery(labels)}`;
-  }
-  return getUser().then(user => {
-    axios({
-      url: reqUrl,
-      headers: {
-        authorization: `Bearer ${user.accessToken}`
-      }
-    }).then(response => response.data);
-  });
-};
-
-const _buildOpenshiftApiUrl = (baseUrl, res) => (res.group ? `${baseUrl}/apis/${res.group}` : `${baseUrl}/api`);
-
-const _buildOpenShiftUrl = (baseUrl, res) => {
-  const urlBegin = `${_buildOpenshiftApiUrl(baseUrl, res)}/${res.version}`;
-  if (res.namespace) {
-    return `${urlBegin}/namespaces/${res.namespace}/${res.name}`;
-  }
-  return `${urlBegin}/${res.name}`;
-};
-
-const _buildRequestUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.masterUri, res)}`;
-
-const _buildWatchUrl = res => `${_buildOpenShiftUrl(window.OPENSHIFT_CONFIG.wssMasterUri, res)}?watch=true`;
-
-const _labelsToQuery = labels => {
-  const labelsArr = map(labels, (value, name) => `${name}%3D${value}`);
-  return labelsArr.join(',');
-};
+const listWithLabels = (res, labels) => OpenshiftResourceManagerFactory.forResource(res.kind).list(res, labels);
 
 export {
   get,


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9435

## What
- Added ability to customise the resource management for each of the resource type
- Added the PushVariantCR object
- Added the PushApplicationCR object
- Customised the behaviour of the PushVariantCR Manager so that variants are managed

## How to test

1. Run the MDC as usual
2. Install the UPS operator in the `mobile-console` namespace
3. Use the UPS operator to create a `UnifiedPush` instance
4. Create an app in MDC
5. Click to the app details
6. Click on mobile services
7. Try to bind and unbind the Push Service. Note that Push Service can be bound 2 times, one for android and one for iOS

## Tasks:
- [x] Add ability to bind an android variant
- [x] Add ability to bind an ios variant 
- [x] Add ability to unbind the variants
- [x] Customise the watchers to be able to support services using more than one custom resource
- [x] Add ability to automatically create the UPS application when creating a variant if it doesn't already exists


## KNOWN BUGS

There is a bug in the binding window: if you select ios and then try to move back to android, the fields does not gets updated. This will be fixed as part of another issue.
