### PR TITLE
fix: remove hard-coded namespace value

### DIFF
--- a/server/appServices.js
+++ b/server/appServices.js
@@ -92,7 +92,9 @@ function updateAppsAndWatch(namespace, kubeclient) {
       }
     });
 
-    const mssConfigMapStream = kubeclient.api.v1.watch.namespace('mobile-security-service-apps').configmaps.getStream();
+    const mssConfigMapStream = kubeclient.api.v1.watch
+      .namespace(_getMobileSecurityServiceAppsNamespace())
+      .configmaps.getStream();
     const mssConfigMapJsonStream = new JSONStream();
     mssConfigMapStream.pipe(mssConfigMapJsonStream);
     mssConfigMapJsonStream.on('data', event => {
@@ -144,6 +146,14 @@ function watchMobileSecurityServiceCR(namespace, kubeclient) {
       MobileSecurityService.disabled = true;
     }
   });
+}
+
+function _getMobileSecurityServiceNamespace() {
+  return process.env.MSS_NAMESPACE || false;
+}
+
+function _getMobileSecurityServiceAppsNamespace() {
+  return process.env.MSS_APPS_NAMESPACE || _getMobileSecurityServiceNamespace();
 }
 
 module.exports = {


### PR DESCRIPTION
## What

Removed the hard coded mobile security service namespace value.

## Why

There is an environment variable that can be passed at runtime to configure this.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run MDC with MSS enabled:

```sh
OPENSHIFT_HOST=$(minishift ip):8443 NAMESPACE=mobile-console OPENSHIFT_USER_TOKEN=$(oc whoami -t) MSS_NAMESPACE=mobile-security-service MSS_APPS_NAMESPACE=mobile-security-service-apps npm run start:server
```

2. Create an app.
3. Bind the mobile security service to the app.
4. `mobile-services.json` should have the mobile security service configuration.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO