### PR TITLE
fix: removed hardcoded namespaces

### DIFF
--- a/server/mobile-services-info.js
+++ b/server/mobile-services-info.js
@@ -155,7 +155,7 @@ const MobileSecurityService = {
   description: 'Mobile Security Service',
   bindCustomResource: {
     name: 'mobilesecurityserviceapps',
-    namespace: 'mobile-security-service-apps',
+    namespace: process.env.MSS_APPS_NAMESPACE || process.env.MSS_NAMESPACE,
     version: 'v1alpha1',
     group: 'mobile-security-service.aerogear.com',
     kind: 'MobileSecurityServiceApp'

--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -88,7 +88,6 @@ export class MobileSecurityServiceAppCR extends CustomResource {
       kind: 'MobileSecurityServiceApp',
       metadata: {
         name: `${appName}-security`,
-        namespace: 'mobile-security-service-apps',
         labels: {
           'mobile.aerogear.org/client': appName
         }


### PR DESCRIPTION
## What

Removed the hard coded mobile security service apps namespace value.

## Why

There is an environment variable that can be passed at runtime to configure this.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run MDC with MSS enabled:

```sh
OPENSHIFT_HOST=$(minishift ip):8443 NAMESPACE=mobile-console OPENSHIFT_USER_TOKEN=$(oc whoami -t) MSS_NAMESPACE=mobile-security-service MSS_APPS_NAMESPACE=mobile-security-service-apps npm run start:server
```

2. Create an app.
3. Bind the mobile security service to the app.
4. `mobile-services.json` should have the mobile security service configuration.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO