### PR TITLE
refactor(url): use environment variable to display route to MSS

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -50,7 +50,8 @@ const DEFAULT_SERVICES = {
       type: DataSyncService.type
     },
     {
-      type: MobileSecurityService.type
+      type: MobileSecurityService.type,
+      url: `https://${process.env.MSS_URL || process.env.OPENSHIFT_HOST}`
     }
   ]
 };

--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -64,10 +64,7 @@ class BoundServiceRow extends Component {
     let propertyFragment;
 
     const docUrl = this.props.service.getDocumentationUrl();
-    const serviceConfigurations = this.props.service.getConfiguration(
-      this.props.appName,
-      this.props.configurationOptions
-    );
+    const serviceConfigurations = this.props.service.getConfiguration(this.props.appName);
 
     if (docUrl) {
       documentationFragment = (

--- a/src/components/mobileservices/MobileServiceView.js
+++ b/src/components/mobileservices/MobileServiceView.js
@@ -26,36 +26,6 @@ class MobileServiceView extends Component {
     this.props.fetchAndWatchServices();
   }
 
-  /**
-   * Used to provide custom configuration values to the BoundServiceRow and UnboundServiceRow.
-   *
-   * @param {String} type - The service type
-   * @returns {Object}
-   * @memberof MobileServiceView
-   */
-  getConfigurationOptions(type) {
-    if (!this.props.app) {
-      return null;
-    }
-
-    const {
-      status: {
-        data: { services }
-      }
-    } = this.props.app;
-
-    let options = {};
-    if (type === 'security') {
-      const securityService = services.find(s => s.name === 'security');
-      if (securityService) {
-        options = {
-          url: securityService.url
-        };
-      }
-    }
-    return options;
-  }
-
   boundServiceRows() {
     return (
       <React.Fragment>
@@ -66,7 +36,6 @@ class MobileServiceView extends Component {
               key={service.getId()}
               appName={this.props.appName}
               service={service}
-              configurationOptions={this.getConfigurationOptions(service.data.type, this.props.app)}
               onCreateBinding={() => this.showBindingPanel(service)}
               onFinished={this.hideBindingPanel}
               onDeleteBinding={cr => this.props.deleteCustomResource(service, cr.toJSON())}

--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -11,12 +11,12 @@ export class MobileSecurityServiceAppCR extends CustomResource {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  getConfiguration(_, options) {
+  getConfiguration(serviceHost) {
     return [
       {
         type: 'href',
         label: 'Mobile Security Service URL',
-        value: options.url
+        value: serviceHost
       }
     ];
   }

--- a/src/models/mobileservices/mobileservice.js
+++ b/src/models/mobileservices/mobileservice.js
@@ -94,9 +94,9 @@ export class MobileService {
     return this.customResourceClass.newInstance(formdata);
   }
 
-  getConfiguration(appName, options) {
+  getConfiguration(appName) {
     const crs = this.getCustomResourcesForApp(appName);
-    const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.url, options)), []);
+    const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.url)), []);
     const uniqConfigs = uniqBy(configurations, config => config.label);
     return uniqConfigs;
   }


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9597

## What

Use an environment variable value to display the route to the Mobile Security Service from a bound service row.

## Why

This is what is done in the other services.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run MDC with the following command:

```
MSS_URL=route-mobile-security-service.192.168.42.114.nip.io OPENSHIFT_USER_TOKEN=$(oc whoami -t) npm run start:server
```

2. Ensure that the Mobile Security Service is running. You can use [this script](https://gist.github.com/craicoverflow/dbe3f56188bb7f033926ac4c335be0ac#file-install-mss-sh) to install it on your cluster, or contact me for my cluster credentials.
3. Create an app and bind the Mobile Security Service to it.
4. In the bound service view, you should see the URL.

![Screenshot from 2019-07-15 16-42-24](https://user-images.githubusercontent.com/11743717/61229178-9eb50900-a71f-11e9-81b7-b1a8c9481b88.png)


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO