### PR TITLE
update the format of the service list

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -116,10 +116,11 @@ function getConfigData(req) {
     userName = req.get('X-Forwarded-User');
     userEmail = req.get('X-Forwarded-Email');
   }
-  const parsedHost = new URL(process.env.OPENSHIFT_HOST);
-  if (!parsedHost.protocol) {
-    parsedHost.protocol = 'https';
+  let host = process.env.OPENSHIFT_HOST;
+  if (host && host.indexOf('http') === -1) {
+    host = `https://${host}`;
   }
+  const parsedHost = new URL(host);
   const masterUri = parsedHost.toString().slice(0, -1);
   parsedHost.protocol = 'wss';
   const wssMasterUri = parsedHost.toString().slice(0, -1);

--- a/server/server.js
+++ b/server/server.js
@@ -126,9 +126,9 @@ function getConfigData(req) {
   let host = process.env.OPENSHIFT_HOST;
   host = addProtocolIfMissing(host);
   const parsedHost = new URL(host);
-  const masterUri = parsedHost.toString().slice(0, -1);
+const masterUri = parsedHost.origin;
   parsedHost.protocol = 'wss';
-  const wssMasterUri = parsedHost.toString().slice(0, -1);
+const wssMasterUri = parsedHost.origin;
 
   return `window.OPENSHIFT_CONFIG = {
     mdcNamespace: '${mdcNamespace}',

--- a/server/server.js
+++ b/server/server.js
@@ -2,11 +2,11 @@ const express = require('express');
 const path = require('path');
 const bodyParser = require('body-parser');
 const promMid = require('express-prometheus-middleware');
-const Prometheus = require('prom-client');
 const { Client } = require('kubernetes-client');
 const Request = require('kubernetes-client/backends/request');
 const packageJson = require('../package.json');
 const fs = require('fs');
+const { URL } = require('url');
 const {
   IdentityManagementService,
   DataSyncService,
@@ -35,37 +35,39 @@ app.use(
 
 const port = process.env.PORT || 4000;
 const configPath = process.env.MOBILE_SERVICES_CONFIG_FILE || '/etc/mdc/servicesConfig.json';
+const dataSyncService = {
+  type: DataSyncService.type,
+  mobile: true
+};
 const DEFAULT_SERVICES = {
-  services: [
+  version: 'dev',
+  components: [
     {
       type: IdentityManagementService.type,
-      url: `https://${process.env.IDM_URL || process.env.OPENSHIFT_HOST}`
+      version: 'latest',
+      host: `https://${process.env.IDM_URL || process.env.OPENSHIFT_HOST}`,
+      mobile: true
     },
     {
       type: PushService.type,
-      url: `https://${process.env.UPS_URL || process.env.OPENSHIFT_HOST}`
+      host: `https://${process.env.UPS_URL || process.env.OPENSHIFT_HOST}`,
+      version: 'latest',
+      mobile: true
     },
     // {
     //   type: MetricsService.type,
     //   url: `https://${process.env.METRICS_URL || process.env.OPENSHIFT_HOST}`
     // }
     {
-      type: DataSyncService.type
-    },
-    {
       type: MobileSecurityService.type,
-      url: `https://${process.env.MSS_URL || process.env.OPENSHIFT_HOST}`
+      host: `https://${process.env.MSS_URL || process.env.OPENSHIFT_HOST}`,
+      version: 'latest',
+      mobile: true
     }
   ]
 };
 
 const DEFAULT_NAMESPACE = 'mobile-console';
-
-// metric endpoint
-app.get('/metrics', (req, res) => {
-  res.set('Content-Type', Prometheus.register.contentType);
-  res.end(Prometheus.register.metrics());
-});
 
 // Dynamic configuration for openshift API calls
 app.get('/api/server_config.js', (req, res) => {
@@ -114,6 +116,13 @@ function getConfigData(req) {
     userName = req.get('X-Forwarded-User');
     userEmail = req.get('X-Forwarded-Email');
   }
+  const parsedHost = new URL(process.env.OPENSHIFT_HOST);
+  if (!parsedHost.protocol) {
+    parsedHost.protocol = 'https';
+  }
+  const masterUri = parsedHost.toString().slice(0, -1);
+  parsedHost.protocol = 'wss';
+  const wssMasterUri = parsedHost.toString().slice(0, -1);
 
   return `window.OPENSHIFT_CONFIG = {
     mdcNamespace: '${mdcNamespace}',
@@ -121,8 +130,8 @@ function getConfigData(req) {
       namespace: '${mssNamespace}',
       appsNamespace: '${mssAppsNamespace}'
     },
-    masterUri: 'https://${process.env.OPENSHIFT_HOST}',
-    wssMasterUri: 'wss://${process.env.OPENSHIFT_HOST}',
+    masterUri: '${masterUri}',
+    wssMasterUri: '${wssMasterUri}',
     user: {
       accessToken: '${userToken}',
       name: '${userName}',
@@ -145,7 +154,8 @@ function getServices(servicesConfigPath) {
     console.warn(`can not find service config file at ${servicesConfigPath}, mock data will be used`);
     return resolve(DEFAULT_SERVICES);
   })
-    .then(servicesUrls => servicesUrls.services)
+    .then(servicesUrls => servicesUrls.components.concat([dataSyncService]))
+    .then(services => services.filter(s => s.mobile))
     .then(services =>
       services.map(service => {
         const serviceInfo = MobileServicesMap[service.type];

--- a/server/server.js
+++ b/server/server.js
@@ -39,18 +39,25 @@ const dataSyncService = {
   type: DataSyncService.type,
   mobile: true
 };
+
+const addProtocolIfMissing = function(url) {
+  if (url && !url.startsWith('http')) {
+    return `https://${url}`;
+  }
+  return url;
+};
 const DEFAULT_SERVICES = {
   version: 'dev',
   components: [
     {
       type: IdentityManagementService.type,
       version: 'latest',
-      host: `https://${process.env.IDM_URL || process.env.OPENSHIFT_HOST}`,
+      host: addProtocolIfMissing(`${process.env.IDM_URL || process.env.OPENSHIFT_HOST}`),
       mobile: true
     },
     {
       type: PushService.type,
-      host: `https://${process.env.UPS_URL || process.env.OPENSHIFT_HOST}`,
+      host: addProtocolIfMissing(`${process.env.UPS_URL || process.env.OPENSHIFT_HOST}`),
       version: 'latest',
       mobile: true
     },
@@ -60,7 +67,7 @@ const DEFAULT_SERVICES = {
     // }
     {
       type: MobileSecurityService.type,
-      host: `https://${process.env.MSS_URL || process.env.OPENSHIFT_HOST}`,
+      host: addProtocolIfMissing(`${process.env.MSS_URL || process.env.OPENSHIFT_HOST}`),
       version: 'latest',
       mobile: true
     }
@@ -117,9 +124,7 @@ function getConfigData(req) {
     userEmail = req.get('X-Forwarded-Email');
   }
   let host = process.env.OPENSHIFT_HOST;
-  if (host && host.indexOf('http') === -1) {
-    host = `https://${host}`;
-  }
+  host = addProtocolIfMissing(host);
   const parsedHost = new URL(host);
   const masterUri = parsedHost.toString().slice(0, -1);
   parsedHost.protocol = 'wss';

--- a/server/server.js
+++ b/server/server.js
@@ -126,9 +126,9 @@ function getConfigData(req) {
   let host = process.env.OPENSHIFT_HOST;
   host = addProtocolIfMissing(host);
   const parsedHost = new URL(host);
-const masterUri = parsedHost.origin;
+  const masterUri = parsedHost.origin;
   parsedHost.protocol = 'wss';
-const wssMasterUri = parsedHost.origin;
+  const wssMasterUri = parsedHost.origin;
 
   return `window.OPENSHIFT_CONFIG = {
     mdcNamespace: '${mdcNamespace}',

--- a/src/models/mobileservices/mobileservice.js
+++ b/src/models/mobileservices/mobileservice.js
@@ -96,7 +96,7 @@ export class MobileService {
 
   getConfiguration(appName) {
     const crs = this.getCustomResourcesForApp(appName);
-    const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.url)), []);
+    const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.host)), []);
     const uniqConfigs = uniqBy(configurations, config => config.label);
     return uniqConfigs;
   }


### PR DESCRIPTION
## Motivation

Update the format of the service list file to match what is generated by the installer. See https://github.com/integr8ly/installation/pull/748/files#r304318416


## What

* Update the format of the services list and filter them using the `mobile:true` flag
* Remove the redundant `/metrics` endpoint. It is added by the Prometheus middleware automatically
* Fix the OPENSHIFT_HOST url if the protocol is specified as part of the env var 

## Verification Steps

* Run MDC and everything should still work as expected. 
* Add or remove the protocol value of the OPENSHIFT_HOST env var and it should still work.
* The `/metrics` endpoint should still work.
 

