### PR TITLE
refactor(kubeclient): remove deprecation warnings

### DIFF
--- a/server/appServices.js
+++ b/server/appServices.js
@@ -66,32 +66,26 @@ function getServicesForApp(namespace, app, kubeclient) {
   return Promise.all(promises).then(serviceConfigs => serviceConfigs.filter(Boolean));
 }
 
-function updateAppsAndWatch(namespace, kubeclient) {
+async function updateAppsAndWatch(namespace, kubeclient) {
   updateAll(namespace, kubeclient).then(async () => {
     watchMobileClients(namespace, kubeclient);
 
-    const secretStream = kubeclient.api.v1.watch.namespace(namespace).secrets.getStream();
-    const secretsJsonStream = new JSONStream();
-    secretStream.pipe(secretsJsonStream);
-    secretsJsonStream.on('data', event => {
+    const secretStream = await kubeclient.api.v1.watch.namespace(namespace).secrets.getObjectStream();
+    secretStream.on('data', event => {
       if (event.object && event.object.metadata.name.endsWith(KEYCLOAK_SECRET_SUFFIX)) {
         updateAll(namespace, kubeclient);
       }
     });
 
-    const configmapStream = kubeclient.api.v1.watch.namespace(namespace).configmaps.getStream();
-    const configmapJsonStream = new JSONStream();
-    configmapStream.pipe(configmapJsonStream);
-    configmapJsonStream.on('data', event => {
+    const configmapStream = await kubeclient.api.v1.watch.namespace(namespace).configmaps.getObjectStream();
+    configmapStream.on('data', event => {
       if (event.object && event.object.metadata.name.endsWith(DATASYNC_CONFIGMAP_SUFFIX)) {
         updateAll(namespace, kubeclient);
       }
     });
 
-    const mssConfigMapStream = kubeclient.api.v1.watch.namespace(namespace).configmaps.getStream();
-    const mssConfigMapJsonStream = new JSONStream();
-    mssConfigMapStream.pipe(mssConfigMapJsonStream);
-    mssConfigMapJsonStream.on('data', event => {
+    const mssConfigMapStream = await kubeclient.api.v1.watch.namespace(namespace).configmaps.getObjectStream();
+    mssConfigMapStream.on('data', event => {
       if (event.object && event.object.metadata.name.endsWith(MOBILE_SECURITY_SUFFIX)) {
         updateAll(namespace, kubeclient);
       }

--- a/server/server.js
+++ b/server/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const bodyParser = require('body-parser');
 const promMid = require('express-prometheus-middleware');
-const { Client } = require('kubernetes-client');
+const { Client, KubeConfig } = require('kubernetes-client');
 const Request = require('kubernetes-client/backends/request');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -176,9 +176,13 @@ function getServices(servicesConfigPath) {
 
 async function initKubeClient() {
   try {
-    const conf =
-      process.env.NODE_ENV === 'production' ? Request.config.getInCluster() : Request.config.fromKubeconfig();
-    const backend = new Request(conf);
+    const kubeconfig = new KubeConfig();
+    if (process.env.NODE_ENV === 'production') {
+      kubeclient.loadFromCluster();
+    } else {
+      kubeconfig.loadFromDefault();
+    }
+    const backend = new Request({ kubeconfig });
 
     if (process.env.INSECURE_SERVER) {
       backend.requestOptions.strictSSL = false;


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9602

## What

Removed deprecation warnings for [godaddy/kubernetes-client](https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md) library.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run the MDC server: `OPENSHIFT_HOST=$(minishift ip):8443 OPENSHIFT_USER_TOKEN=$(oc whoami -t) npm run start:server`
2. There will now only be 3 deprecation warnings printed in the console on startup:

```sh
kubernetes-client deprecated .getStream see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md server/appServices.js:67:22                  
kubernetes-client deprecated .getStream see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md server/appServices.js:97:24                  
kubernetes-client deprecated .getStream see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md server/appServices.js:108:20
```

3. Run the MDC UI. MDC should still work as normal.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Additional Notes

Three deprecation warning still appear. These are related to streaming `watch` endpoints on custom resource. The documentation for using `getObjectStream()` (which removes this warning and works fine on default resources such as pods) does not work for streaming custom resources.

See [merging-with-kubernetes.md#getstream](https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md#getstream).

I have an open issue https://github.com/godaddy/kubernetes-client/issues/517 about this.
 

