### PR TITLE
fix: return filestream result as promise

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -35,6 +35,7 @@ app.use(
 
 const port = process.env.PORT || 4000;
 const configPath = process.env.MOBILE_SERVICES_CONFIG_FILE || '/etc/mdc/servicesConfig.json';
+
 const dataSyncService = {
   type: DataSyncService.type,
   mobile: true
@@ -149,7 +150,7 @@ function getConfigData(req) {
 function getServices(servicesConfigPath) {
   return new Promise(resolve => {
     if (fs.existsSync(servicesConfigPath)) {
-      fs.readFile(servicesConfigPath, (err, data) => {
+      return fs.readFile(servicesConfigPath, (err, data) => {
         if (err) {
           console.error(`Failed to read service config file ${servicesConfigPath}, mock data will be used`);
           return resolve(DEFAULT_SERVICES);


### PR DESCRIPTION
## What

`fs.readFile` was never returning, meaning that the `DEFAULT_SERVICES` were getting returned instead.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Create a file in `$HOME/generated_secret`.
2. Add the following JSON object to it:

```
{
        "version": "master",
        "components": [
                {
                        "name": "webapp",
                        "version": "2.10.5",
                        "host": "https://tutorial-web-app-webapp.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "3scale",
                        "version": "2.5.0.GA",
                        "host": "https://3scale-admin.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "apicurito",
                        "version": "0.2.18.Final",
                        "host": "https://apicurito-app.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "codeready",
                        "version": "1.2.0.GA",
                        "host": "https://codeready-codeready.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "rh-sso",
                        "version": "7.3.2.GA",
                        "host": "https://sso-sso.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "gitea",
                        "version": "1.6.0",
                        "host": "http://gitea.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "launcher",
                        "version": "7224e235226ffa42135f148bacc409e9f7f402e4",
                        "host": "https://launcher-launcher.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "fuse_online",
                        "version": "7.3",
                        "host": "https://syndesis-fuse.apps.demo27-8353.openshiftworkshop.com"
                },
                {
                        "name": "fuse_openshift",
                        "version": "7.3",
                        "host": ""
                },
                {
                        "name": "enmasse",
                        "version": "1.1.1.GA",
                        "host": "https://master.demo27-8353.openshiftworkshop.com:443/apis/enmasse.io"
                },
                {
                        "name": "Identity Management",
                        "version": "7.3.2.GA",
                        "host": "https://sso-user-sso.apps.demo27-8353.openshiftworkshop.com",
                        "type": "keycloak",
                        "mobile": "true"
                },
                {
                        "name": "Mobile Security Service",
                        "version": "0.1.0",
                        "host": "https://route-mobile-security-service.apps.demo27-8353.openshiftworkshop.com",
                        "type": "security",
                        "mobile": "true"
                },
                {
                        "name": "Unified Push Server",
                        "version": "2.2.1.Final",
                        "host": "https://unifiedpush-unifiedpush-proxy-unifiedpush.apps.demo27-8353.openshiftworkshop.com",
                        "type": "push",
                        "mobile": "true"
                },
                {
                        "name": "Mobile Developer Console",
                        "version": "master",
                        "host": "https://mdc-mdc-proxy-mobile-developer-console.apps.demo27-8353.openshiftworkshop.com"
                }
        ]
}
```

3. Run MDC with the following environment variable: `MOBILE_SERVICES_CONFIG_FILE=$HOME/generated_secret`.
4. View the `/api/mobileservices` endpoint, either in your browser or in developer tools. The returned JSON should be the same as the file at $HOME/generated_secret

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO