### PR TITLE
fix(form): mobile client type form was not updating

### DIFF
--- a/src/components/mobileservices/BindingPanel.js
+++ b/src/components/mobileservices/BindingPanel.js
@@ -65,10 +65,13 @@ export class BindingPanel extends Component {
     const { formData } = data;
     if (this.state.onChangeHandler) {
       const newSchema = this.state.onChangeHandler(formData, this.state.schema);
-      return this.setState({
-        formData,
-        schema: newSchema
-      });
+
+      if (newSchema) {
+        return this.setState({
+          formData: {},
+          schema: newSchema
+        });
+      }
     }
     return this.setState({ formData });
   }

--- a/src/models/mobileservices/pushvariantcr.js
+++ b/src/models/mobileservices/pushvariantcr.js
@@ -132,15 +132,15 @@ export class PushVariantCR extends CustomResource {
       onChangeHandler(formData, oldSchema) {
         const s = oldSchema;
         if (oldSchema.properties.platformConfig.title === 'Android' && formData.CLIENT_TYPE === 'iOS') {
-          delete s.properties.platformConfig;
           s.properties.CLIENT_TYPE.default = 'iOS';
           s.properties.platformConfig = iosConfig;
+          return s;
         } else if (oldSchema.properties.platformConfig.title === 'iOS' && formData.CLIENT_TYPE === 'Android') {
-          delete s.properties.platformConfig;
           s.properties.CLIENT_TYPE.default = 'Android';
           s.properties.platformConfig = androidConfig;
+          return s;
         }
-        return s;
+        return null;
       },
       validationRules: {
         UPSCOMMON: {


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9605

## What

The Mobile Client Type form was not updating to match the chosen type from the dropdown toggle when binding the Push Notification Service.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Start to bind the Push Notification service to an app.
2. Toggle the Android/iOS choice a few times. The form below should always update to match the chosen type.
3. Complete the binding.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO