### PR TITLE
Fix(Binding Form): Fix issue with reseting error message on validation

### DIFF
--- a/src/components/mobileservices/BindingPanel.js
+++ b/src/components/mobileservices/BindingPanel.js
@@ -33,7 +33,8 @@ export class BindingPanel extends Component {
       service,
       activeStepIndex: 0,
       validationRules,
-      onChangeHandler
+      onChangeHandler,
+      key: Date.now() // required to reset any possible validation errors
     };
   }
 
@@ -69,7 +70,8 @@ export class BindingPanel extends Component {
       if (newSchema) {
         return this.setState({
           formData: {},
-          schema: newSchema
+          schema: newSchema,
+          key: Date.now() // reset any possible validation errors
         });
       }
     }
@@ -79,6 +81,7 @@ export class BindingPanel extends Component {
   renderPropertiesSchema() {
     return (
       <Form
+        key={this.state.key} // required to reset any possible validation errors
         schema={this.state.schema}
         uiSchema={this.state.uiSchema}
         ref={form => {


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9618

## What
Validation errors were not been reset of a mobile client type when the mobile client type was been changed.

## Why
This seems to be the only work around  for this issue. See [https://github.com/mozilla-services/react-jsonschema-form/issues/486](https://github.com/mozilla-services/react-jsonschema-form/issues/486) for background into the solution.

## How
Add a key to form which when changed creates a new form instance which clears validation errors.

## Verification Steps
1. Bind a new push notification service
2. Try create binding with blank form to cause validation errors
3. Switch the mobile client type
4. Switch back to previous mobile client type
5. No errors should be shown

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO


