### PR TITLE
feat(docs-link): add custom link to downstream service docs

### DIFF
--- a/server/mobile-services.js
+++ b/server/mobile-services.js
@@ -22,6 +22,7 @@ const IOS_UPS_SUFFIX = '-ios-ups-variant';
 const ANDROID_UPS_SUFFIX = '-android-ups-variant';
 
 const configPath = process.env.MOBILE_SERVICES_CONFIG_FILE || '/etc/mdc/servicesConfig.json';
+const { UPS_DOCUMENTATION_URL, IDM_DOCUMENTATION_URL, MSS_DOCUMENTATION_URL, SYNC_DOCUMENTATION_URL } = process.env;
 
 function decodeBase64(encoded) {
   const buff = Buffer.from(encoded, 'base64');
@@ -33,6 +34,7 @@ const PushService = {
   name: 'Push Notification',
   icon: '/img/push.svg',
   description: 'Unified Push Server',
+  documentationUrl: UPS_DOCUMENTATION_URL,
   bindCustomResource: {
     name: 'pushapplications',
     version: 'v1alpha1',
@@ -149,6 +151,7 @@ const IdentityManagementService = {
   name: 'Identity Management',
   icon: '/img/keycloak.svg',
   description: 'Identity Management Service',
+  documentationUrl: IDM_DOCUMENTATION_URL,
   bindCustomResource: {
     name: 'keycloakrealms',
     version: 'v1alpha1',
@@ -208,6 +211,7 @@ const DataSyncService = {
   name: 'Data Sync',
   icon: '/img/sync.svg',
   description: 'Data Sync Service',
+  documentationUrl: SYNC_DOCUMENTATION_URL,
   bindCustomResource: {
     name: 'configmaps',
     version: 'v1',
@@ -255,6 +259,7 @@ const MobileSecurityService = {
   name: 'Mobile Security',
   icon: '/img/security.svg',
   description: 'Mobile Security Service',
+  documentationUrl: MSS_DOCUMENTATION_URL,
   bindCustomResource: {
     name: 'mobilesecurityserviceapps',
     version: 'v1alpha1',

--- a/server/server.js
+++ b/server/server.js
@@ -57,8 +57,6 @@ function getConfigData(req) {
     OPENSHIFT_USER_NAME,
     OPENSHIFT_USER_EMAIL,
     NAMESPACE,
-    MSS_NAMESPACE,
-    MSS_APPS_NAMESPACE,
     ENABLE_BUILD_TAB,
     DOCS_PREFIX
   } = process.env;
@@ -66,8 +64,6 @@ function getConfigData(req) {
   let userName = OPENSHIFT_USER_NAME || 'testuser';
   let userEmail = OPENSHIFT_USER_EMAIL || 'testuser@localhost';
   const mdcNamespace = NAMESPACE || DEFAULT_NAMESPACE;
-  const mssNamespace = MSS_NAMESPACE || false;
-  const mssAppsNamespace = MSS_APPS_NAMESPACE || MSS_NAMESPACE;
   const docsPrefix = DOCS_PREFIX || 'https://docs.aerogear.org/aerogear/latest';
   let enableBuildTab = false;
   if (ENABLE_BUILD_TAB && ENABLE_BUILD_TAB === 'true') {
@@ -88,17 +84,13 @@ function getConfigData(req) {
 
   return `window.OPENSHIFT_CONFIG = {
     mdcNamespace: '${mdcNamespace}',
-    mss: {
-      namespace: '${mssNamespace}',
-      appsNamespace: '${mssAppsNamespace}'
-    },
     masterUri: '${masterUri}',
     wssMasterUri: '${wssMasterUri}',
     user: {
       accessToken: '${userToken}',
       name: '${userName}',
       email: '${userEmail}'
-    }
+    },
   }; window.SERVER_DATA= { ENABLE_BUILD_TAB: ${enableBuildTab}, DOCS_PREFIX: '${docsPrefix}' };`;
 }
 

--- a/src/models/mobileservices/mobileservice.js
+++ b/src/models/mobileservices/mobileservice.js
@@ -140,8 +140,20 @@ export class MobileService {
     return configExtItems;
   }
 
+  /**
+   * Return the docuemntation URL for this service. Firs try to load from an enviroment variable,
+   * otherwise default to the upstream URL.
+   *
+   * @returns the service documentation URL
+   * @memberof MobileService
+   */
   getDocumentationUrl() {
-    return this.customResourceClass.getDocumentationUrl();
+    let url = this.data.documentationUrl;
+    if (this.data.documentationUrl && !this.data.documentationUrl.startsWith('http')) {
+      url = `https://${url}`;
+    }
+
+    return url || this.customResourceClass.getDocumentationUrl();
   }
 
   toJSON() {


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9621

## What

Added ability to link to downstream docs for each mobile service. When set this will override the downstream documentation link.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run MDC with all services running in your cluster, with the following environment variables:

* `UPS_DOCUMENTATION_URL=www.google.ie`
* `IDM_DOCUMENTATION_URL=https://en.wikipedia.org`
* `SYNC_DOCUMENTATION_URL=www.bing.com`
* `MSS_DOCUMENTATION_URL=https://www.github.com`.

2. Bind each of the services to an app.
3. In each Bound Service, click the `SDK Setup` link. They should direct you to the URLs defined in step 1.
4. Repeat these steps, except this time exclude some or all of the documentation URL environment variables. The SDK Setup link should direct you to docs.aerogear.com

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO