### PR TITLE
Fix: Fix wording in Create App Model

### DIFF
--- a/src/components/create_client/EditMobileClientBaseClass.js
+++ b/src/components/create_client/EditMobileClientBaseClass.js
@@ -62,8 +62,8 @@ class EditMobileClientBaseClass extends Component {
         <Grid bsClass="create-client-form">
           <Form vertical="true">{generatedFields}</Form>
         </Grid>
-        <p>JavaScript-based mobile apps can be configured for a variety of mobile platforms.</p>
-        <p>Our JavaScript SDK supports the following frameworks:</p>
+        <p>Create cross-platform mobile apps using JavaScript.</p>
+        <p>You can use the following JavaScript frameworks:</p>
         <Row className="show-grid container">
           <Col md={1} className="text-center">
             <img src="/img/cordova.jpg" width="25" height="25" alt="React logo" />


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9628

## What
Fix wording in Create App Model

## How
Replace 'Our JavaScript SDK **supports** the following frameworks' with 'Our JavaScript SDK **can be used with** the following frameworks'

## Verification Steps
1. Create Mobile App in MDC
2. Create Mobile App model should have the text block:
> *Create cross-platform mobile apps using Javascript.
>  You can use the following JavaScript frameworks:*

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO


