### PR TITLE
fix: undefined variable

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -178,7 +178,7 @@ async function initKubeClient() {
   try {
     const kubeconfig = new KubeConfig();
     if (process.env.NODE_ENV === 'production') {
-      kubeclient.loadFromCluster();
+      kubeconfig.loadFromCluster();
     } else {
       kubeconfig.loadFromDefault();
     }


### PR DESCRIPTION
An undefined variable `kubeclient` was being referenced which does not exist. `kubeconfig` should have been used.

```
oc logs -f example-mdc-1-jbfqd -c mdc
npm info it worked if it ends with ok
npm info using npm@6.9.0
npm info using node@v10.16.0
npm info lifecycle ui@0.1.0~prestart: ui@0.1.0
npm info lifecycle ui@0.1.0~start: ui@0.1.0
> ui@0.1.0 start /opt/app-root/src
> node server/server.js
Failed to init kube client ReferenceError: kubeclient is not defined
    at initKubeClient (/opt/app-root/src/server/server.js:181:7)
    at run (/opt/app-root/src/server/server.js:224:28)
    at Object.<anonymous> (/opt/app-root/src/server/server.js:231:1)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:829:12)
    at startup (internal/bootstrap/node.js:283:19)
Check services for all apps
(node:17) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'apis' of null
    at updateAll (/opt/app-root/src/server/appServices.js:25:21)
    at updateAppsAndWatch (/opt/app-root/src/server/appServices.js:70:3)
    at run (/opt/app-root/src/server/server.js:226:3)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:832:11)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
(node:17) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:17) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Listening on port 4000
```

## Verification Steps

1. Deploy MDC to Minishift by running the following commands:

```
./scripts/minishift_start.sh
./scripts/prepare.sh
./deploy/deploy-image.sh $(minishift ip):8443 mobile-console
```

2. MDC should provision and you should be able to open it.