### PR TITLE
fix: permissions error on AndroidVariant, IOSVariant custom resources

### DIFF
--- a/src/services/crmanagers/PushVariantResourceManager.js
+++ b/src/services/crmanagers/PushVariantResourceManager.js
@@ -64,7 +64,9 @@ export class PushVariantResourceManager extends GenericResourceManager {
   }
 
   list(user, res, labels) {
-    return Promise.all(res.variants.map(variantRes => super.list(user, variantRes, labels))).then(results => {
+    return Promise.all(
+      res.variants.map(variantRes => super.list(user, { ...variantRes, namespace: res.namespace }, labels))
+    ).then(results => {
       const result = results[0];
       result.kind = 'Variants';
       delete result.metadata;
@@ -82,6 +84,6 @@ export class PushVariantResourceManager extends GenericResourceManager {
   }
 
   watch(user, res) {
-    return Promise.all(res.variants.map(variantRes => super.watch(user, variantRes)));
+    return Promise.all(res.variants.map(variantRes => super.watch(user, { ...variantRes, namespace: res.namespace })));
   }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-9654

When logged in as a regular user (evals01), androidvariants and iosvariants failed to load, getting a 403 with the following error message:

"iosvariants.push.aerogear.org is forbidden: User \"evals01\" cannot list iosvariants.push.aerogear.org at the cluster scope: no RBAC policy matched".

This was because the API request for these resources was cluster-scoped.

This pull request changed the request to be look at the same namespace as the parent PushApplication resource.

**To verify**

1. Login to https://mdc-mdc-proxy-mobile-developer-console.apps.mdsdemo-710a.openshiftworkshop.com/ cluster as evals01@example.com / Password1
2. Check the browser developer console. You should not be getting 403 errors on these resources.

![Screenshot from 2019-07-31 10-16-54](https://user-images.githubusercontent.com/11743717/62200036-7f071d00-b37c-11e9-9b1f-ceb55edf13da.png)
