### PR TITLE
maxlength realmId

### DIFF
--- a/src/components/mobileservices/validator/rules/MaxLengthRule.js
+++ b/src/components/mobileservices/validator/rules/MaxLengthRule.js
@@ -1,0 +1,34 @@
+import { get } from 'lodash-es';
+import { ValidationRuleBaseClass } from './ValidationRuleBaseClass';
+
+/**
+ * This is a very simple rule. Checks that the configured field value length is greater than the one that is expected.
+ * It must be configured inside the JSON file as follows:
+ * {
+ *   "type": "maxlength",  // this must be exactly 'maxlength'
+ *   "length" 36,          // the maximum length limit of this field value
+ *   "error": "Your error message"          // Optional. The custom error message.
+ *                                          // This can be a string, a dictionary or a function (signature: (key, message) => {})
+ *                                          // If not specified, a standard error message is returned.
+ * }
+ */
+export class MaxLengthRule extends ValidationRuleBaseClass {
+  constructor(config) {
+    super(config);
+    this.maxlength = config.length;
+  }
+
+  validate(formData, key) {
+    const value = get(formData, key);
+
+    if (value.length > this.maxlength) {
+      return {
+        valid: false,
+        error: this.getErrorMessage({ key, message: `${key} is too big, maximum length is ${this.maxlength}` })
+      };
+    }
+    return { valid: true };
+  }
+}
+
+export const NAME = 'maxlength';

--- a/src/components/mobileservices/validator/rules/MaxLengthRule.js
+++ b/src/components/mobileservices/validator/rules/MaxLengthRule.js
@@ -2,14 +2,11 @@ import { get } from 'lodash-es';
 import { ValidationRuleBaseClass } from './ValidationRuleBaseClass';
 
 /**
- * This is a very simple rule. Checks that the configured field value length is greater than the one that is expected.
- * It must be configured inside the JSON file as follows:
+ * Checks that the passed in value has a length smaller or equal than the configured maxlength property.
+ *
  * {
  *   "type": "maxlength",  // this must be exactly 'maxlength'
  *   "length" 36,          // the maximum length limit of this field value
- *   "error": "Your error message"          // Optional. The custom error message.
- *                                          // This can be a string, a dictionary or a function (signature: (key, message) => {})
- *                                          // If not specified, a standard error message is returned.
  * }
  */
 export class MaxLengthRule extends ValidationRuleBaseClass {
@@ -24,7 +21,10 @@ export class MaxLengthRule extends ValidationRuleBaseClass {
     if (value.length > this.maxlength) {
       return {
         valid: false,
-        error: this.getErrorMessage({ key, message: `${key} is too big, maximum length is ${this.maxlength}` })
+        error: this.getErrorMessage({
+          key,
+          message: `${key} is too long, maximum length is ${this.maxlength} characters`
+        })
       };
     }
     return { valid: true };

--- a/src/components/mobileservices/validator/rules/MaxLengthRule.test.js
+++ b/src/components/mobileservices/validator/rules/MaxLengthRule.test.js
@@ -1,0 +1,18 @@
+import { MaxLengthRule } from './MaxLengthRule';
+
+describe('MaxLengthRule', () => {
+  const length = 5;
+  const rule = new MaxLengthRule({ length });
+
+  it('should be valid', () => {
+    const result = rule.validate({ data: '1234' }, 'data');
+
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('should be invalid', () => {
+    const result = rule.validate({ data: '123456' }, 'data');
+
+    expect(result).toEqual({ valid: false, error: 'data is too big, maximum length is 5' });
+  });
+});

--- a/src/components/mobileservices/validator/rules/MaxLengthRule.test.js
+++ b/src/components/mobileservices/validator/rules/MaxLengthRule.test.js
@@ -4,15 +4,21 @@ describe('MaxLengthRule', () => {
   const length = 5;
   const rule = new MaxLengthRule({ length });
 
-  it('should be valid', () => {
+  it('should validate a value that has length lower than the allowed maxlength', () => {
     const result = rule.validate({ data: '1234' }, 'data');
 
     expect(result).toEqual({ valid: true });
   });
 
-  it('should be invalid', () => {
+  it('should not validate a value that has length greater than the allowed maxlength', () => {
     const result = rule.validate({ data: '123456' }, 'data');
 
-    expect(result).toEqual({ valid: false, error: 'data is too big, maximum length is 5' });
+    expect(result).toEqual({ valid: false, error: 'data is too long, maximum length is 5 characters' });
+  });
+
+  it('should validate value with the exact length', () => {
+    const result = rule.validate({ data: '12345' }, 'data');
+
+    expect(result).toEqual({ valid: true });
   });
 });

--- a/src/components/mobileservices/validator/rules/ValidationRule.js
+++ b/src/components/mobileservices/validator/rules/ValidationRule.js
@@ -2,6 +2,7 @@ import { NAME as REQUIRED, RequiredRule } from './RequiredRule';
 import { NAME as SAMEVALUEOF, SameValueOfRule } from './SameValueOfRule';
 import { NAME as P12VALIDATOR, P12ValidationRule } from './P12ValidatorRule';
 import { NAME as REGEXP, RegExpRule } from './RegExpRule';
+import { NAME as MAXLENGTH, MaxLengthRule } from './MaxLengthRule';
 import { NoopRule } from './NoopRule';
 
 /**
@@ -23,6 +24,9 @@ export class ValidationRule {
       }
       case REGEXP: {
         return new RegExpRule(ruleConfig);
+      }
+      case MAXLENGTH: {
+        return new MaxLengthRule(ruleConfig);
       }
       default: {
         return new NoopRule();

--- a/src/models/mobileservices/keycloakrealmcr.js
+++ b/src/models/mobileservices/keycloakrealmcr.js
@@ -91,8 +91,7 @@ export class KeycloakRealmCR extends CustomResource {
                 validation_rules: [
                   {
                     type: 'maxlength',
-                    length: 36,
-                    error: 'realm id is too big, max length is 36 chars'
+                    length: 36
                   }
                 ]
               },

--- a/src/models/mobileservices/keycloakrealmcr.js
+++ b/src/models/mobileservices/keycloakrealmcr.js
@@ -77,9 +77,6 @@ export class KeycloakRealmCR extends CustomResource {
           }
         },
         realmSettings: {
-          realmId: {
-            'ui:readonly': true
-          },
           adminPassword: {
             'ui:widget': 'password'
           }
@@ -90,6 +87,15 @@ export class KeycloakRealmCR extends CustomResource {
           comment: 'This is the set of rules that will be used to validate IDM bindings',
           fields: {
             realmSettings: {
+              realmId: {
+                validation_rules: [
+                  {
+                    type: 'maxlength',
+                    length: 36,
+                    error: 'realm id is too big, max length is 36 chars'
+                  }
+                ]
+              },
               adminUsername: {
                 validation_rules: [
                   {


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AGMS-619

## What
* adds field value size limit for the auth realmId field (36)

## Why
Keycloak database realm id/name schema has a max size limit of 36 chars.

## How
* Created a new MaxLengthRule validation rule
* RealmId field can now be edited when binding an auth service

## Verification Steps
* Build an image using this branch and deploy it
* Bind an auth service using a realm id that has a length greater than 36 chars 
* The form should throw an error
* Edit the realm id value and use a value that is small enough
* Form submission should work now.
## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

I have an image available with the mentioned changes: `docker.io/odranoel/mdc:dev`
