### PR TITLE
feat(validation): prevent mobile security service binding if app id exists

### DIFF
--- a/src/actions/services.js
+++ b/src/actions/services.js
@@ -67,6 +67,7 @@ export const createCustomResourceForService = (service, formdata, app) => async 
   // we don't need to handle success event here as it will be handled by the WS handler
   return create(resDef, reqBody, app).catch(err => {
     dispatch(errorCreator(err));
+    throw err;
   });
 };
 

--- a/src/components/mobileservices/BindingPanel.js
+++ b/src/components/mobileservices/BindingPanel.js
@@ -131,7 +131,10 @@ export class BindingPanel extends Component {
   stepChanged = step => {
     if (step === 2) {
       this.setState({ loading: true });
-      this.props.createCustomResourceForService(this.state.service, this.state.formData, this.props.app);
+      this.props.createCustomResourceForService(this.state.service, this.state.formData, this.props.app).catch(() => {
+        // go back one step as the custom resource failed to create
+        this.setState({ loading: false, activeStepIndex: 1 });
+      });
     }
   };
 

--- a/src/services/crmanagers/MobileSecurityAppResourceManager.js
+++ b/src/services/crmanagers/MobileSecurityAppResourceManager.js
@@ -1,0 +1,15 @@
+import { GenericResourceManager } from './GenericResourceManager';
+
+export class MobileSecurityAppResourceManager extends GenericResourceManager {
+  async create(user, res, obj, owner) {
+    const apps = await super.list(user, res);
+
+    const app = apps.items.find(item => item.spec.appId === obj.spec.appId);
+
+    if (app) {
+      return Promise.reject(new Error('An app with this identifier already exists'));
+    }
+
+    return super.create(user, res, obj, owner);
+  }
+}

--- a/src/services/crmanagers/ResourceManagerFactory.js
+++ b/src/services/crmanagers/ResourceManagerFactory.js
@@ -1,6 +1,7 @@
 import { GenericResourceManager } from './GenericResourceManager';
 import { PushVariantResourceManager } from './PushVariantResourceManager';
 import { getUser } from '../openshift';
+import { MobileSecurityAppResourceManager } from './MobileSecurityAppResourceManager';
 
 /**
  * This class delegates all his operation to the provided resource manager.
@@ -26,6 +27,8 @@ class UserBoundResourceManager {
 export class ResourceManagerFactory {
   static forResource(kind) {
     switch (kind) {
+      case 'MobileSecurityServiceApp':
+        return new UserBoundResourceManager(new MobileSecurityAppResourceManager());
       case 'pushapplications':
       case 'AndroidVariant':
       case 'IOSVariant':


### PR DESCRIPTION
https://issues.jboss.org/browse/AGMS-701

This change will prevent multiple apps with the same unique ID getting bound to the Mobile Security Service.

1. Create an app.
2. Bind Mobile Security with an app ID "com.myapp".
3. Create a second app.
4. Try to bind Mobile Security again with the same app ID.
5. You should get an error message and the binding will be prevented.