### PR TITLE
fix: remove ability to set client type in wizard

### DIFF
--- a/src/models/mobileservices/keycloakrealmcr.js
+++ b/src/models/mobileservices/keycloakrealmcr.js
@@ -58,7 +58,6 @@ export class KeycloakRealmCR extends CustomResource {
               },
               CLIENT_TYPE: {
                 default: 'public',
-                enum: ['bearer', 'public'],
                 title: 'Client type',
                 type: 'string'
               }
@@ -74,6 +73,9 @@ export class KeycloakRealmCR extends CustomResource {
         clientSettings: {
           clientId: {
             'ui:readonly': true
+          },
+          CLIENT_TYPE: {
+            'ui:widget': 'hidden'
           }
         },
         realmSettings: {


### PR DESCRIPTION
https://issues.jboss.org/browse/AGMS-620

This change removes the ability for the end-user to set the client type when binding an app to Keycloak. Bearer is not a valid type for a mobile app, so instead the type defaults to "public".

## Verification

1. Create an app.
2. Bind Identity Management. Notice you will not see the option to set client type any more in the wizard.
3. Once bound, view the custom resource created. For example, here is my app, "myapp-realm".

```sh
$ oc get keycloakrealms myapp-realm -o json | grep 'publicClient'
	"publicClient": true,
```

The default value "public" was used to set it to a public client.