### PR TITLE
Fixed websocket url for insecure routes

### DIFF
--- a/server/mobile-services.js
+++ b/server/mobile-services.js
@@ -229,8 +229,9 @@ const DataSyncService = {
           const serverUrl = url.parse(configmap.data.syncServerUrl);
           serverUrl.pathname = configmap.data.graphqlEndpoint;
           const httpUrl = url.format(serverUrl);
-          serverUrl.protocol = 'wss';
-          const websocketUrl = url.format(serverUrl);
+          const serverWsUrl = url.parse(httpUrl);
+          serverWsUrl.protocol = serverUrl.protocol === 'http:' ? 'ws:' : 'wss:';
+          const websocketUrl = url.format(serverWsUrl);
           return {
             id: configmap.metadata.uid,
             name: DATA_SYNC_TYPE,


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9713

## What
Correctly adding **ws** protocol to the websocket url when sync is insecure **http**

## Why
It was always **wss** previously
 
## How
Fixing configuration generation for Data Sync.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Create mobile client
2. Go to the mobile client
3. Go to `Mobile apps >> Mobile services`
4. Create a new `Data sync` binding with insecure `http` url
5. Check generated `mobile-services.json` on the `Configuration` page  and there should be `ws` in the `websocketUrl` field
![image](https://user-images.githubusercontent.com/2912228/62694247-43033600-b9d4-11e9-9dae-2e37e41c20ed.png)
6. Recreate steps 1-3 with different client
7. Now bind a `Data sync` with secure `https` url
8. Check generated `mobile-services.json` on the `Configuration` page and there should be `wss` in the `websocketUrl` field

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
