### PR TITLE
Fix: MSS binding validation to be case insensitive

### DIFF
--- a/src/services/crmanagers/MobileSecurityAppResourceManager.js
+++ b/src/services/crmanagers/MobileSecurityAppResourceManager.js
@@ -4,10 +4,10 @@ export class MobileSecurityAppResourceManager extends GenericResourceManager {
   async create(user, res, obj, owner) {
     const apps = await super.list(user, res);
 
-    const app = apps.items.find(item => item.spec.appId === obj.spec.appId);
+    const app = apps.items.find(item => item.spec.appId.toLowerCase() === obj.spec.appId.toLowerCase());
 
     if (app) {
-      return Promise.reject(new Error('An app with this identifier already exists'));
+      return Promise.reject(new Error('App identifier already exists'));
     }
 
     return super.create(user, res, obj, owner);


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AGMS-753

## What
Update to validation checks on existing MSS to be case insensitive

## Why
Possible issue on iOS and android devices with case sensitive names 

## How
In check for existing MMS id's the id's are convert to lower case and then checked.

## Verification Steps
 
1. Create an app in MDC
2. Bind MSS to that app with Unique App Identifier, eg: `com.myapp`
3. Create a second app in MDC
4. Try bind MSS to the second app using an upper-case Unique App Identifier from step 2, eg: `COM.MYAPP`
5. Result: Error message returned saying `App identifier already exists` 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
![image](https://user-images.githubusercontent.com/10224565/62707058-9ed7ba00-b9e8-11e9-850e-7c3cceeda303.png)

