### PR TITLE
Refactor: MSS url not taken from configmap

### DIFF
--- a/server/mobile-security-crd.json
+++ b/server/mobile-security-crd.json
@@ -1,0 +1,22 @@
+{
+  "kind": "CustomResourceDefinition", 
+  "spec": {
+    "scope": "Namespaced", 
+    "versions": [{
+      "name": "v1alpha1",
+      "served": true,
+      "storage": true
+    }],
+    "group": "mobile-security-service.aerogear.org",
+    "names": {
+      "kind": "MobileSecurityServiceApp", 
+      "listKind": "MobileSecurityServiceAppList",
+      "plural": "mobilesecurityserviceapps", 
+      "singular": "mobilesecurityserviceapp"
+    }
+  }, 
+  "apiVersion": "apiextensions.k8s.io/v1beta1", 
+  "metadata": {
+    "name": "mobilesecurityserviceapps.mobilesecurityservice.aerogear.org"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ const mobileClientCRD = require('./mobile-client-crd.json');
 const pushApplicationCRD = require('./push-application-crd.json');
 const androidVariantCRD = require('./android-variant-crd.json');
 const iosVariantCRD = require('./ios-variant-crd.json');
+const mobileSecurityService = require('./mobile-security-crd.json');
 
 const app = express();
 
@@ -114,6 +115,7 @@ async function initKubeClient() {
     kubeclient.addCustomResourceDefinition(pushApplicationCRD);
     kubeclient.addCustomResourceDefinition(androidVariantCRD);
     kubeclient.addCustomResourceDefinition(iosVariantCRD);
+    kubeclient.addCustomResourceDefinition(mobileSecurityService);
     return kubeclient;
   } catch (e) {
     console.error('Failed to init kube client', e);


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AGMS-805

## What
Change how the url for MSS is created in the mobile.services.json file.

## Why
The use of the config map is been removed from the MSS

## How
Change how the `getServices()` works for MSS resources

## Verification Steps
1. Create an app
2. Bind the mobile security service to the app
3. With a successfully bind the url should be shown in the mobile-services.json.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

