### PR TITLE
fix: application freezes during regular expression check

### DIFF
--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -69,9 +69,9 @@ export class MobileSecurityServiceAppCR extends CustomResource {
                   },
                   {
                     type: 'regexp',
-                    regexp: /^(?:[-a-zA-Z]+(?:\d*[a-zA-Z_]*)*)(?:\.[-a-zA-Z]+(?:\d*[a-zA-Z_]*)*)+$/,
+                    regexp: /^[-a-zA-Z][a-zA-Z0-9_]*(\.[-a-zA-Z]+[-a-zA-Z0-9_]*[^.]?)+$/,
                     error:
-                      'Unique identifier must have at least two segments separated by dots (.). Each segment must start with a letter or a hyphen. Valid characters: [a-zA-Z0-9_-].'
+                      'Unique identifier must have at least two segments separated by dots (.). Each segment must start with a letter, hyphen or underscore. Valid characters: [a-zA-Z0-9_-].'
                   }
                 ]
               }


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-9749

The regular expression was inefficient and was causing the application to freeze with a long app ID.

# Verification

1. Create an app.
2. Go to bind Mobile Security.
3. Enter the following string as app ID:  "V0AhG1Tntt19LjszklOgzMeYrJzfffsdfkfddddddddddddddddddddddddddddddddskdkadksdkdff".
4. The following validation message should appear:

_Unique identifier must have at least two segments separated by dots (.). Each segment must start with a letter or a hyphen. Valid characters: [a-zA-Z0-9_-]._

5. Change the app ID to something valid, for example:

"-com.example.myapp"

6. Mobile security should bind successfully.