### PR TITLE
refactor(maxlength): added a max length for app ID

### DIFF
--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -68,6 +68,11 @@ export class MobileSecurityServiceAppCR extends CustomResource {
                     error: 'Unique identifier is required.'
                   },
                   {
+                    type: 'maxlength',
+                    length: 255,
+                    error: 'Unique identifer is too long. Maximum length allowed is 255 characters.'
+                  },
+                  {
                     type: 'regexp',
                     regexp: /^[-a-zA-Z][a-zA-Z0-9_]*(\.[-a-zA-Z]+[-a-zA-Z0-9_]*[^.]?)+$/,
                     error:


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-9748

Added a maxlength rule on the Mobile Security Service app ID.

## Verification

1. Create an app.
2. Click "Bind to App" on Mobile Security.
3. Enter a string > 255 characters.
4. The validation rule. should prevent the binding.

Depends on https://github.com/aerogear/mobile-developer-console/pull/373