### PR TITLE
refactor: make anonymous function synchronous and remove unnecessary condition.

### DIFF
--- a/server/appServices.js
+++ b/server/appServices.js
@@ -67,7 +67,7 @@ function getServicesForApp(namespace, app, kubeclient) {
 }
 
 async function updateAppsAndWatch(namespace, kubeclient) {
-  updateAll(namespace, kubeclient).then(async () => {
+  updateAll(namespace, kubeclient).then(() => {
     watchMobileClients(namespace, kubeclient);
     watchDataSyncConfigMaps(namespace, kubeclient);
     watchKeyCloakSecrets(namespace, kubeclient);


### PR DESCRIPTION
- Made function synchronous as it no longer needed to be async.
- Remove condition which prevented mobileclients from getting updated multiple times in parallel. The apps will still update fine without it.

## Verification

Binding/unbinding should still work as normal. You will see 409 errors in the console but this is okay as MDC tries to update the app multiple times.