### PR TITLE
fix(pages): update styles

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,6 +7,7 @@ import {
   Page,
   PageHeader,
   PageSection,
+  PageSectionVariants,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,
@@ -96,7 +97,7 @@ class App extends React.Component {
             />
           }
         >
-          <PageSection>
+          <PageSection variant={PageSectionVariants.light}>
             <Switch>
               <Route exact path="/overview" component={Overview} />
               <Route exact path="/mobileclient/:id" component={Client} />

--- a/src/components/common/CopyToClipboardMultiline.css
+++ b/src/components/common/CopyToClipboardMultiline.css
@@ -10,7 +10,7 @@
   flex-direction: column; }
   .copy-to-clipboard-multiline pre span {
     display: block;
-    line-height: 1.5rem; }
+    line-height: 1rem; }
     .copy-to-clipboard-multiline pre span:before {
       counter-increment: line;
       content: counter(line);

--- a/src/components/common/CopyToClipboardMultiline.scss
+++ b/src/components/common/CopyToClipboardMultiline.scss
@@ -12,7 +12,7 @@
 
         span {
             display: block;
-            line-height: 1.5rem;
+            line-height: 1rem;
 
             &:before {
                 counter-increment: line;

--- a/src/components/configuration/ConfigurationView.css
+++ b/src/components/configuration/ConfigurationView.css
@@ -6,10 +6,15 @@
     width: 30px;
     height: 30px; }
   .configurationView .list-group-item-container {
-    padding-top: 24px;
-    padding-right: 36px;
-    padding-bottom: 24px;
-    padding-left: 36px; }
+    padding-top: 16px;
+    padding-right: 24px;
+    padding-bottom: 16px;
+    padding-left: 24px; }
+    .configurationView .list-group-item-container ol {
+      margin-left: 32px; }
+    .configurationView .list-group-item-container ol > li > ul {
+      list-style-type: disc;
+      margin-left: 32px; }
   .configurationView .list-group-item-header {
     background-color: transparent;
     margin-top: 8px;

--- a/src/components/configuration/ConfigurationView.css
+++ b/src/components/configuration/ConfigurationView.css
@@ -25,7 +25,6 @@
     margin-right: 8px; }
 
 .configurationView > * {
-  flex: 1 100%;
   margin-right: 16px;
   display: flex;
   flex-direction: column; }

--- a/src/components/configuration/ConfigurationView.css
+++ b/src/components/configuration/ConfigurationView.css
@@ -5,6 +5,11 @@
   .configurationView .icon {
     width: 30px;
     height: 30px; }
+  .configurationView .list-group-item-container {
+    padding-top: 24px;
+    padding-right: 36px;
+    padding-bottom: 24px;
+    padding-left: 36px; }
   .configurationView .list-group-item-header {
     background-color: transparent;
     margin-top: 8px;

--- a/src/components/configuration/ConfigurationView.scss
+++ b/src/components/configuration/ConfigurationView.scss
@@ -39,7 +39,6 @@
 }
 
 .configurationView > * {
-  flex: 1 100%;
   margin-right: 16px;
   display: flex;
   flex-direction: column;

--- a/src/components/configuration/ConfigurationView.scss
+++ b/src/components/configuration/ConfigurationView.scss
@@ -9,6 +9,21 @@
     height: 30px;
   }
   
+  .list-group-item-container {
+    padding-top: 16px;
+    padding-right: 24px;
+    padding-bottom: 16px;
+    padding-left: 24px;
+
+    ol {
+      margin-left: 32px;
+    }
+
+    ol > li> ul {
+      list-style-type: disc;
+      margin-left: 32px;
+    }
+  }
   
   .list-group-item-header {
     background-color: transparent;

--- a/src/components/configuration/ConfigurationView.scss
+++ b/src/components/configuration/ConfigurationView.scss
@@ -8,8 +8,14 @@
     width: 30px;
     height: 30px;
   }
-  
-  
+
+  .list-group-item-container {
+    padding-top: 24px;
+    padding-right: 36px;
+    padding-bottom: 24px;
+    padding-left: 36px;
+  }
+
   .list-group-item-header {
     background-color: transparent;
     margin-top: 8px;

--- a/src/components/configuration/ConfigurationView.scss
+++ b/src/components/configuration/ConfigurationView.scss
@@ -9,6 +9,7 @@
     height: 30px;
   }
 
+
   .list-group-item-header {
     background-color: transparent;
     margin-top: 8px;

--- a/src/components/configuration/ConfigurationView.scss
+++ b/src/components/configuration/ConfigurationView.scss
@@ -9,13 +9,6 @@
     height: 30px;
   }
 
-  .list-group-item-container {
-    padding-top: 24px;
-    padding-right: 36px;
-    padding-bottom: 24px;
-    padding-left: 36px;
-  }
-
   .list-group-item-header {
     background-color: transparent;
     margin-top: 8px;

--- a/src/components/configuration/ConfigurationView.scss
+++ b/src/components/configuration/ConfigurationView.scss
@@ -8,8 +8,8 @@
     width: 30px;
     height: 30px;
   }
-
-
+  
+  
   .list-group-item-header {
     background-color: transparent;
     margin-top: 8px;

--- a/src/components/configuration/ServiceSDKInfo.css
+++ b/src/components/configuration/ServiceSDKInfo.css
@@ -1,5 +1,6 @@
 .service-sdk-info {
-  padding: 0px; }
+  padding: 0px;
+  width: unset; }
 
 .service-sdk-info img {
   width: 30px;

--- a/src/components/configuration/ServiceSDKInfo.scss
+++ b/src/components/configuration/ServiceSDKInfo.scss
@@ -1,5 +1,6 @@
 .service-sdk-info {
   padding: 0px;
+  width: unset;
 }
 
 .service-sdk-info img {


### PR DESCRIPTION
## Motivation
https://github.com/aerogear/mobile-developer-console/issues/378

## What
Fixed styles after the new patternfly updates

## Why
the pf updates didn't account for some of the styles

## How
Add PageSectionVariants to the app.js file and change it to light.

## Verification Steps
I added screenshots, but you could run this locally and check the background color
 
## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1083" alt="Screen Shot 2019-08-14 at 4 22 10 PM" src="https://user-images.githubusercontent.com/20118816/63053968-f1194f00-beb0-11e9-9da6-04e81798ab44.png">

<img width="1085" alt="Screen Shot 2019-08-14 at 4 22 23 PM" src="https://user-images.githubusercontent.com/20118816/63053969-f1194f00-beb0-11e9-9ddf-e751c74f03ff.png">

I was also seeing this when I ran the code so unset the width:
<img width="995" alt="Screen Shot 2019-08-14 at 4 43 15 PM" src="https://user-images.githubusercontent.com/20118816/63054890-b31d2a80-beb2-11e9-91fd-5baa47315557.png">

 