### PR TITLE
Fix(Service List): Add missing services to the configuration files for cordova and ionic

### DIFF
--- a/src/components/configuration/sdk-config-docs/cordova.js
+++ b/src/components/configuration/sdk-config-docs/cordova.js
@@ -101,6 +101,26 @@ const framework = docsPrefix => {
             ]
           }
         ]
+      },
+      security: {
+        serviceLogoUrl: '/img/security.svg',
+        serviceName: 'Security',
+        serviceDescription:
+          'Installs a service which allows you remotely disable specific app variants from the Mobile Security Console.',
+        setupText: 'Security SDK setup',
+        docsLink: `${docsPrefix}/security.html`,
+        steps: [
+          {
+            introduction: 'Setting up Mobile Security service SDK',
+            commands: [
+              ['Install the AeroGear Security package from NPM', '```npm install @aerogear/security --save```'],
+              [
+                'Add the AeroGear Security plugin for Cordova',
+                '```cordova plugin add @aerogear/cordova-plugin-aerogear-security```'
+              ]
+            ]
+          }
+        ]
       }
     }
   };

--- a/src/components/configuration/sdk-config-docs/ionic.js
+++ b/src/components/configuration/sdk-config-docs/ionic.js
@@ -106,6 +106,26 @@ const framework = docsPrefix => {
             ]
           }
         ]
+      },
+      security: {
+        serviceLogoUrl: '/img/security.svg',
+        serviceName: 'Security',
+        serviceDescription:
+          'Installs a service which allows you remotely disable specific app variants from the Mobile Security Console.',
+        setupText: 'Security SDK setup',
+        docsLink: `${docsPrefix}/security.html`,
+        steps: [
+          {
+            introduction: 'Setting up Mobile Security service SDK',
+            commands: [
+              ['Install the AeroGear Security package from NPM', '```npm install @aerogear/security --save```'],
+              [
+                'Add the AeroGear Security plugin for Cordova',
+                '```cordova plugin add @aerogear/cordova-plugin-aerogear-security```'
+              ]
+            ]
+          }
+        ]
       }
     }
   };


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9770

## What
The Mobile Security Service details was add to the condova and ionic configuration files.

## Why
When binding a mobile security service to an app the links to the service documentation was not shown 

## How
Update config file

## Verification Steps
1. Create an app in MDC
2. Bind MSS to the app
3. Under the configuration tab, check Cordova and Ionic both show *Security* in the `Service specific documentation` section
4. Follow the links to external docs. These should point to the AreaGear docs. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 

