### PR TITLE
Fixed issue AEROGEAR-8283

### DIFF
--- a/src/components/mobileservices/BindingPanel.js
+++ b/src/components/mobileservices/BindingPanel.js
@@ -138,6 +138,10 @@ export class BindingPanel extends Component {
     }
   };
 
+  isInProgress() {
+    return this.state.loading;
+  }
+
   /**
    * see https://github.com/mozilla-services/react-jsonschema-form/tree/6cb26d17c0206b610b130729db930d5906d3fdd3#form-data-validation
    */
@@ -203,5 +207,7 @@ function mapStateToProps(state, ownProps) {
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
+  null,
+  { withRef: true }
 )(BindingPanel);

--- a/src/components/mobileservices/BindingStatus.js
+++ b/src/components/mobileservices/BindingStatus.js
@@ -11,12 +11,12 @@ class BindingStatus extends Component {
   }
 
   updateState() {
-    if (this.props.service.isBindingOperationInProgress() && !this.state.hasStarted) {
+    if (this.props.service.isBindingOperationInProgress(this.props.appName) && !this.state.hasStarted) {
       this.setState({
         hasStarted: true
       });
     }
-    if (this.state.hasStarted && !this.props.service.isBindingOperationInProgress()) {
+    if (this.state.hasStarted && !this.props.service.isBindingOperationInProgress(this.props.appName)) {
       this.props.onFinished();
       this.setState({
         hasStarted: false
@@ -28,8 +28,11 @@ class BindingStatus extends Component {
     this.props.onFinished();
   }
 
-  render() {
+  componentDidMount() {
     this.updateState();
+  }
+
+  render() {
     return (
       <ListView.InfoItem key="bind-status">
         {this.props.service.isBindingOperationInProgress() && (

--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -117,6 +117,7 @@ class BoundServiceRow extends Component {
         key={`${this.props.service.getId()}binding status`}
         service={this.props.service}
         onFinished={this.props.onFinished}
+        appName={this.props.appName}
       />
     );
   }

--- a/src/components/mobileservices/MobileServiceView.js
+++ b/src/components/mobileservices/MobileServiceView.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { EmptyState, Spinner } from 'patternfly-react';
 import { connect } from 'react-redux';
 import { partition } from 'lodash-es';
+
 import BoundServiceRow from './BoundServiceRow';
 import UnboundServiceRow from './UnboundServiceRow';
 import './MobileServiceView.css';
@@ -12,6 +13,8 @@ import { MobileService, MobileApp } from '../../models/';
 export class MobileServiceView extends Component {
   constructor(props) {
     super(props);
+
+    this.bindingPanelRef = React.createRef();
 
     this.state = {
       bindingPanelService: null
@@ -56,6 +59,7 @@ export class MobileServiceView extends Component {
           this.props.unboundServices.map(service => (
             <UnboundServiceRow
               key={service.getId()}
+              appName={this.props.appName}
               service={service}
               onCreateBinding={() => this.showBindingPanel(service)}
               onFinished={this.hideBindingPanel}
@@ -78,8 +82,8 @@ export class MobileServiceView extends Component {
     });
   };
 
-  hideBindingPanel = () => {
-    if (this.state.bindingPanelService) {
+  hideBindingPanel = force => {
+    if (this.state.bindingPanelService && (force || this.bindingPanelRef.current.getWrappedInstance().isInProgress())) {
       this.setState({
         bindingPanelService: null
       });
@@ -99,10 +103,11 @@ export class MobileServiceView extends Component {
         </Spinner>
         {this.state.bindingPanelService && (
           <BindingPanel
+            ref={this.bindingPanelRef}
             appName={this.props.appName}
             service={this.state.bindingPanelService}
             showModal
-            close={this.hideBindingPanel}
+            close={() => this.hideBindingPanel(true)}
           />
         )}
       </div>

--- a/src/components/mobileservices/UnboundServiceRow.js
+++ b/src/components/mobileservices/UnboundServiceRow.js
@@ -51,6 +51,7 @@ class UnboundServiceRow extends Component {
         key={`${this.props.service.getId()}binding status`}
         service={this.props.service}
         onFinished={this.props.onFinished}
+        appName={this.props.appName}
       />
     );
   }

--- a/src/models/mobileservices/customresource.js
+++ b/src/models/mobileservices/customresource.js
@@ -1,3 +1,4 @@
+import { get } from 'lodash-es';
 import Resource from '../k8s/resource';
 import Status from '../k8s/status';
 
@@ -36,6 +37,10 @@ export class CustomResource extends Resource {
   isInProgress() {
     const phase = this.status.get('phase');
     return CustomResource.INPROGRESS_STATUSES.indexOf(phase) > -1;
+  }
+
+  getOwners() {
+    return get(this, 'data.metadata.ownerReferences');
   }
 
   isFailed() {

--- a/src/models/mobileservices/mobileservice.js
+++ b/src/models/mobileservices/mobileservice.js
@@ -64,8 +64,11 @@ export class MobileService {
     return this.customResourceClass.bindForm(params);
   }
 
-  isBindingOperationInProgress() {
-    const inprogressCR = find(this.customResources, cr => cr.isInProgress());
+  isBindingOperationInProgress(owner) {
+    const inprogressCR = find(
+      this.customResources,
+      cr => (owner ? find(cr.getOwners(), o => o.name === owner) : true) && cr.isInProgress()
+    );
     return inprogressCR != null;
   }
 

--- a/src/services/crmanagers/PushVariantResourceManager.js
+++ b/src/services/crmanagers/PushVariantResourceManager.js
@@ -50,7 +50,7 @@ export class PushVariantResourceManager extends GenericResourceManager {
           if (foundApp.status) return foundApp;
           return null;
         },
-        5000,
+        10000,
         1000
       );
     }


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-8283 

## What
Modified the `mobileservice.isBindingOperationInProgress` so that it can receive an `owner` parameter. This way we will be able to ask if a binding operation is in progress for a particular application

Modified the BindingPanel to get closed automatically only if the wizard has reached the latest step and the binding was in progress. This is to avoid that another binding for the same app could cause this window to get closed before the latest step has been reached (since `isBindingOperationInProgress(appName)` would return `false` since this operation has not started yet).

## Why
The binding panel in MDC gets automatically closed when `isBindingOperation` returns 'false'.
Without this change, any binding operation on any application will cause all the opened Binding Panels to get closed, since the `isBindingOperation` is not filtered for a particular application.

## How
Added an `owner` parameter to the `isBindingOperation` method and checking if the wizard has reached the latest step if a `close binding panel` event is received.

## Verification Steps
 
**CASE1**

1. Connect to the mobile-console by using 2 different browsers (using a chrome instance and a chrome incognito mode will work)
2. Create 2 applications (testapp1 and testapp2)
3. Go to the first browser and open testapp1, then start a binding (don't finish it)
4. Go to the second browser and open testapp2, the complete a binding
5. Without the fix, the window on the first browser would close.

**CASE2**

1. Connect to the mobile-console by using 2 different browsers (using a chrome instance and a chrome incognito mode will work)
3. Go to the first browser and open testapp1, then start a binding (don't finish it)
4. Go to the second browser and open testapp1 again, then complete a binding
5. Without the fix, the window on the first browser would close.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Known issues
The window will close automatically when **ALL THE BINDINGS** for the current application and for the selected service will finish. I.E. If an Android and an iOS binding are in progress, the window will automatically close when both of them will end. 
**This is not a regression**: without the fix the window would have closed when all the bindings of the given type would have ended (regardless of the application).

