### PR TITLE
refactor: use the app UID for the service custom resource label instead of the app name

### DIFF
--- a/src/actions/services.js
+++ b/src/actions/services.js
@@ -63,7 +63,7 @@ export const fetchAndWatchServices = () => async (dispatch, getState) => {
 
 export const createCustomResourceForService = (service, formdata, app) => async dispatch => {
   const resDef = service.customResourceDef();
-  const reqBody = service.newCustomResource(formdata);
+  const reqBody = service.newCustomResource(formdata, app.metadata);
   // we don't need to handle success event here as it will be handled by the WS handler
   return create(resDef, reqBody, app).catch(err => {
     dispatch(errorCreator(err));

--- a/src/components/mobileservices/BindingPanel.js
+++ b/src/components/mobileservices/BindingPanel.js
@@ -20,7 +20,7 @@ export class BindingPanel extends Component {
     this.validate = this.validate.bind(this);
     this.onFormChange = this.onFormChange.bind(this);
     const serviceName = this.props.service.getName();
-    const p = { appName: this.props.appName, service: this.props.service };
+    const p = { appName: this.props.appName, appUid: this.props.appUid, service: this.props.service };
     const bindingFormConfig = this.props.service.getBindingForm(p);
     const { schema, uiSchema, validationRules, onChangeHandler } = bindingFormConfig;
     const { service } = this.props;

--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -64,7 +64,7 @@ class BoundServiceRow extends Component {
     let propertyFragment;
 
     const docUrl = this.props.service.getDocumentationUrl();
-    const serviceConfigurations = this.props.service.getConfiguration(this.props.appName);
+    const serviceConfigurations = this.props.service.getConfiguration(this.props.appUid);
 
     if (docUrl) {
       documentationFragment = (
@@ -128,7 +128,7 @@ class BoundServiceRow extends Component {
       return null;
     }
 
-    if (this.props.service.getCustomResourcesForApp(this.props.appName).length >= 2) {
+    if (this.props.service.getCustomResourcesForApp(this.props.appUid).length >= 2) {
       return null;
     }
 
@@ -136,7 +136,8 @@ class BoundServiceRow extends Component {
   }
 
   renderDeleteBindingDropdowns() {
-    const crs = this.props.service.getCustomResourcesForApp(this.props.appName);
+    const crs = this.props.service.getCustomResourcesForApp(this.props.appUid);
+
     return (
       <DropdownKebab id="delete-binding-id" pullRight>
         {crs.map(cr => (

--- a/src/components/mobileservices/MobileServiceView.js
+++ b/src/components/mobileservices/MobileServiceView.js
@@ -38,6 +38,7 @@ export class MobileServiceView extends Component {
             <BoundServiceRow
               key={service.getId()}
               appName={this.props.appName}
+              appUid={this.props.appUid}
               service={service}
               onCreateBinding={() => this.showBindingPanel(service)}
               onFinished={this.hideBindingPanel}
@@ -105,6 +106,7 @@ export class MobileServiceView extends Component {
           <BindingPanel
             ref={this.bindingPanelRef}
             appName={this.props.appName}
+            appUid={this.props.appUid}
             service={this.state.bindingPanelService}
             showModal
             close={() => this.hideBindingPanel(true)}
@@ -118,7 +120,7 @@ export class MobileServiceView extends Component {
 function mapStateToProps(state, oldProp) {
   const app = MobileApp.find(state.apps.items, oldProp.appName);
   const services = state.services.items.map(item => new MobileService(item));
-  const filteredServices = partition(services, service => service.isBoundToApp(oldProp.appName));
+  const filteredServices = partition(services, service => service.isBoundToApp(oldProp.appUid));
   return { ...state.services, app, boundServices: filteredServices[0], unboundServices: filteredServices[1] };
 }
 

--- a/src/components/mobileservices/MobileServiceView.test.js
+++ b/src/components/mobileservices/MobileServiceView.test.js
@@ -20,6 +20,7 @@ describe('MobileServiceView', () => {
     const wrapper = shallow(
       <MobileServiceView
         appName="appName"
+        appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
         boundServices={props.boundServices}
         unboundServices={props.unboundServices}
         fetchAndWatchServices={() => 'appName'}
@@ -52,6 +53,7 @@ describe('MobileServiceView', () => {
     const wrapper = shallow(
       <MobileServiceView
         appName="appName"
+        appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
         boundServices={props.boundServices}
         unboundServices={props.unboundServices}
         fetchAndWatchServices={() => 'appName'}
@@ -115,6 +117,7 @@ describe('MobileServiceView', () => {
         <BrowserRouter>
           <MobileServiceView
             appName="appName"
+            appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
             boundServices={props.boundServices}
             unboundServices={props.unboundServices}
             fetchAndWatchServices={() => 'appName'}
@@ -174,6 +177,7 @@ describe('MobileServiceView', () => {
         <BrowserRouter>
           <MobileServiceView
             appName="appName"
+            appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
             boundServices={props.boundServices}
             unboundServices={props.unboundServices}
             fetchAndWatchServices={() => 'appName'}
@@ -230,6 +234,7 @@ describe('MobileServiceView', () => {
         <BrowserRouter>
           <MobileServiceView
             appName="appName"
+            appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
             boundServices={props.boundServices}
             unboundServices={props.unboundServices}
             fetchAndWatchServices={() => 'appName'}

--- a/src/containers/Client.js
+++ b/src/containers/Client.js
@@ -136,6 +136,7 @@ export class Client extends Component {
 
   render() {
     const mobileApp = this.getMobileApp();
+    const appUid = mobileApp.getUID();
     const clientInfo = { clientId: mobileApp.getName() };
     const { selectedTab } = this.state;
     const appName = this.props.match.params.id;
@@ -171,7 +172,7 @@ export class Client extends Component {
                   <ConfigurationView app={mobileApp} appName={appName} />
                 </TabPane>
                 <TabPane eventKey={TAB_MOBILE_SERVICES.key}>
-                  <MobileServiceView appName={appName} />
+                  <MobileServiceView appName={appName} appUid={appUid} />
                 </TabPane>
                 {this.props.buildTabEnabled ? (
                   <TabPane eventKey={TAB_BUILDS.key}>

--- a/src/models/mobileapps/mobileapp.js
+++ b/src/models/mobileapps/mobileapp.js
@@ -25,6 +25,10 @@ export default class MobileApp {
     return this.metadata.getName();
   }
 
+  getUID() {
+    return this.metadata.getUID();
+  }
+
   getStatus() {
     return this.status;
   }

--- a/src/models/mobileservices/customresource.js
+++ b/src/models/mobileservices/customresource.js
@@ -26,10 +26,10 @@ export class CustomResource extends Resource {
     return CustomResource.READY_STATUSES.indexOf(phase) > -1;
   }
 
-  hasAppLabel(appName) {
+  hasAppLabel(appUid) {
     const labels = this.metadata.get('labels');
     if (labels) {
-      return labels['mobile.aerogear.org/client'] === appName;
+      return labels['mobile.aerogear.org/client'] === appUid;
     }
     return false;
   }

--- a/src/models/mobileservices/datasync.js
+++ b/src/models/mobileservices/datasync.js
@@ -103,7 +103,7 @@ export class DataSyncCR extends CustomResource {
   }
 
   static newInstance(params) {
-    const { CLIENT_ID } = params;
+    const { CLIENT_ID, appUid } = params;
     const { url, graphqlEndpoint } = params.syncServerConfig;
     return {
       apiVersion: 'v1',
@@ -111,7 +111,7 @@ export class DataSyncCR extends CustomResource {
       metadata: {
         name: `${CLIENT_ID}-data-sync-binding`,
         labels: {
-          'mobile.aerogear.org/client': CLIENT_ID
+          'mobile.aerogear.org/client': appUid
         }
       },
       data: {

--- a/src/models/mobileservices/keycloakrealmcr.js
+++ b/src/models/mobileservices/keycloakrealmcr.js
@@ -121,7 +121,7 @@ export class KeycloakRealmCR extends CustomResource {
   }
 
   static newInstance(params) {
-    const { CLIENT_ID } = params;
+    const { CLIENT_ID, appUid } = params;
     const { realmId, adminUsername, adminPassword } = params.realmSettings;
     const { clientId, CLIENT_TYPE } = params.clientSettings;
     return {
@@ -130,7 +130,7 @@ export class KeycloakRealmCR extends CustomResource {
       metadata: {
         name: realmId,
         labels: {
-          'mobile.aerogear.org/client': CLIENT_ID
+          'mobile.aerogear.org/client': appUid
         }
       },
       spec: {

--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -87,14 +87,14 @@ export class MobileSecurityServiceAppCR extends CustomResource {
     };
   }
 
-  static newInstance({ appName, appConfig: { appId } }) {
+  static newInstance({ appName, appUid, appConfig: { appId } }) {
     return {
       apiVersion: 'mobile-security-service.aerogear.org/v1alpha1',
       kind: 'MobileSecurityServiceApp',
       metadata: {
         name: `${appName}-security`,
         labels: {
-          'mobile.aerogear.org/client': appName
+          'mobile.aerogear.org/client': appUid
         }
       },
       spec: {

--- a/src/models/mobileservices/mobileservice.js
+++ b/src/models/mobileservices/mobileservice.js
@@ -44,12 +44,12 @@ export class MobileService {
     return this.customResources.length > 0 && find(this.customResources, cr => cr.isReady());
   }
 
-  isBoundToApp(appName) {
-    return this.customResources.length > 0 && find(this.customResources, cr => cr.isReady() && cr.hasAppLabel(appName));
+  isBoundToApp(uid) {
+    return this.customResources.length > 0 && find(this.customResources, cr => cr.isReady() && cr.hasAppLabel(uid));
   }
 
-  getCustomResourcesForApp(appName) {
-    return filter(this.customResources, cr => cr.hasAppLabel(appName));
+  getCustomResourcesForApp(uid) {
+    return filter(this.customResources, cr => cr.hasAppLabel(uid));
   }
 
   getServiceInstanceName() {
@@ -93,12 +93,12 @@ export class MobileService {
     return this.data.bindCustomResource;
   }
 
-  newCustomResource(formdata) {
-    return this.customResourceClass.newInstance(formdata);
+  newCustomResource(formdata, ownerMetadata) {
+    return this.customResourceClass.newInstance({ appUid: ownerMetadata.uid, ...formdata });
   }
 
-  getConfiguration(appName) {
-    const crs = this.getCustomResourcesForApp(appName);
+  getConfiguration(appUid) {
+    const crs = this.getCustomResourcesForApp(appUid);
     const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.host)), []);
     const uniqConfigs = uniqBy(configurations, config => config.label);
     return uniqConfigs;

--- a/src/models/mobileservices/pushvariantcr.js
+++ b/src/models/mobileservices/pushvariantcr.js
@@ -1,11 +1,12 @@
 import { find } from 'lodash-es';
 import { CustomResource } from './customresource';
 
-function hasPlatform(service, appName, platform) {
+function hasPlatform(service, appUid, platform) {
+  console.log('appName', appUid);
   return (
     service.customResources &&
     find(
-      service.getCustomResourcesForApp(appName),
+      service.getCustomResourcesForApp(appUid),
       cr => typeof cr.getPlatform === 'function' && cr.getPlatform() === platform
     )
   );
@@ -45,8 +46,8 @@ export class PushVariantCR extends CustomResource {
 
   static bindForm(params) {
     const { service } = params;
-    const hasIOS = hasPlatform(service, params.appName, 'IOSVariant');
-    const hasAndroid = hasPlatform(service, params.appName, 'AndroidVariant');
+    const hasIOS = hasPlatform(service, params.appUid, 'IOSVariant');
+    const hasAndroid = hasPlatform(service, params.appUid, 'AndroidVariant');
     let defaultPlatform = 'Android';
     let platforms = ['Android', 'iOS'];
     const androidConfig = {
@@ -235,7 +236,7 @@ export class PushVariantCR extends CustomResource {
   }
 
   static newInstance(params) {
-    const { CLIENT_ID, CLIENT_TYPE } = params;
+    const { CLIENT_ID, CLIENT_TYPE, appUid } = params;
 
     switch (CLIENT_TYPE) {
       case 'Android':
@@ -245,7 +246,7 @@ export class PushVariantCR extends CustomResource {
           metadata: {
             name: `${CLIENT_ID}-android-ups-variant`,
             labels: {
-              'mobile.aerogear.org/client': CLIENT_ID
+              'mobile.aerogear.org/client': appUid
             }
           },
           spec: {


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-9769

This changes the `mobile.aerogear.org` label on the service custom resources to references the mobile client UID instead of the app name. In Kubernetes, labels have a maximum length of 63 characters, so longer app names meant that services couldn't be bound.

## Verification

1. Create an app.
2. Bind all services.
3. Unbind all services.