### PR TITLE
Feat(ErrorMessages): Added better error message around creating new apps that already exist

### DIFF
--- a/src/containers/ErrorMessages.js
+++ b/src/containers/ErrorMessages.js
@@ -2,7 +2,43 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { ToastNotificationList, ToastNotification } from 'patternfly-react';
 import { withRouter } from 'react-router-dom';
+import { get } from 'lodash-es';
 import { dismiss, dismissAll } from '../actions/errors';
+
+const MOBILECLIENT = 'mobileclients';
+const ALREADYEXISTS = 'AlreadyExists';
+
+function errorMessage(error) {
+  try {
+    switch (error.response.data.details.kind) {
+      case MOBILECLIENT:
+        // case to handle MobileClient CRs
+        return { displayMessage: mobileClientError(error), message: error.message };
+      default:
+        return { message: error.message };
+    }
+  } catch (TypeError) {
+    // catch any error if error.response.data.details.kind does not exist
+    return { message: error.message };
+  }
+}
+
+function mobileClientError(error) {
+  try {
+    switch (error.response.data.reason) {
+      case ALREADYEXISTS: {
+        // handle if mobileClient exists
+        const appName = get(error, 'response.data.details.name');
+        return `An app named "${appName}" already exists`;
+      }
+      default:
+        return error.message;
+    }
+  } catch (TypeError) {
+    // catch any errors if error.response.data.reason does not exist
+    return error.message;
+  }
+}
 
 export class ErrorMessages extends Component {
   componentWillMount() {
@@ -13,14 +49,13 @@ export class ErrorMessages extends Component {
   componentWillUnmount() {
     this.unlisten();
   }
-
   render() {
     const { errors, dismissError } = this.props;
     return (
       <ToastNotificationList>
-        {[...new Set(errors.map(error => error.message))].map((error, index) => (
-          <ToastNotification key={index} onDismiss={() => dismissError(error)}>
-            <span>{error}</span>
+        {[...new Set(errors.map(error => errorMessage(error)))].map((error, index) => (
+          <ToastNotification key={index} onDismiss={() => dismissError(error.message)}>
+            <span>{error.displayMessage || error.message}</span>
           </ToastNotification>
         ))}
       </ToastNotificationList>
@@ -43,3 +78,5 @@ export default withRouter(
     mapDispatchToProps
   )(ErrorMessages)
 );
+
+export { errorMessage, mobileClientError, MOBILECLIENT, ALREADYEXISTS };

--- a/src/containers/ErrorMessages.test.js
+++ b/src/containers/ErrorMessages.test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import { ErrorMessages } from './ErrorMessages';
+import { ErrorMessages, errorMessage, mobileClientError, MOBILECLIENT, ALREADYEXISTS } from './ErrorMessages';
 
 describe('ErrorMessages', () => {
   it('test render', () => {
@@ -23,5 +23,66 @@ describe('ErrorMessages', () => {
         .childAt(1)
         .text()
     ).toEqual('error2');
+  });
+});
+
+const ERRORMESSAGE = 'error message';
+const APPNAME = 'myapp';
+
+describe('mobileClientError() returns correct value', () => {
+  it('return alreadyesixts Switch Case error message', () => {
+    const expected = `An app named "${APPNAME}" already exists`;
+    const error = {
+      message: ERRORMESSAGE,
+      response: { data: { details: { name: APPNAME }, reason: ALREADYEXISTS } }
+    };
+    expect(mobileClientError(error)).toEqual(expected);
+  });
+
+  it('Default case for response.data.reason error message returned', () => {
+    const expected = ERRORMESSAGE;
+    const error = { message: ERRORMESSAGE, response: { data: { reason: 'unknown' } } };
+    expect(mobileClientError(error)).toEqual(expected);
+  });
+
+  it('value response.data.reason does not exist', () => {
+    const expected = ERRORMESSAGE;
+    const error = { message: ERRORMESSAGE };
+    expect(mobileClientError(error)).toEqual(expected);
+  });
+
+  it('value response.data.details.name does not exist', () => {
+    const expected = `An app named "undefined" already exists`;
+    const error = {
+      message: ERRORMESSAGE,
+      response: { data: { reason: ALREADYEXISTS } }
+    };
+    expect(mobileClientError(error)).toEqual(expected);
+  });
+});
+
+describe('errorMessage() returns correct value', () => {
+  it('error message for a mobileClient CR Switch Case', () => {
+    const expected = { displayMessage: `An app named "${APPNAME}" already exists`, message: ERRORMESSAGE };
+    const error = {
+      message: ERRORMESSAGE,
+      response: { data: { details: { kind: MOBILECLIENT, name: APPNAME }, reason: ALREADYEXISTS } }
+    };
+    expect(errorMessage(error)).toEqual(expected);
+  });
+
+  it('No Switch Case for CR found, Default return', () => {
+    const expected = { message: ERRORMESSAGE };
+    const error = {
+      message: ERRORMESSAGE,
+      response: { data: { details: { kind: 'fake CR' }, reason: ALREADYEXISTS } }
+    };
+    expect(errorMessage(error)).toEqual(expected);
+  });
+
+  it('value response.data.details.kind does not exist', () => {
+    const expected = { message: ERRORMESSAGE };
+    const error = { message: ERRORMESSAGE };
+    expect(errorMessage(error)).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9711

## What
Add response checking for the ErrorMessage component to handle kind of MobileClient CR

## Why
To add better messages displayed to the users

## How
In ErrorMessage.js there is checks in place looking for the `response.data.details.kind` of `mobileclients` and `response.data.reason` of `AlreadyExists` is the error type. This should only happen when a new app is been created with an existing name.

## Verification Steps
1. Create a new app, eg: myapp
2. Try create a new app with the existing app name, myapp
3. Error message shown will display a meaningfully error message
4. Error message should close when X is pressed

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
![image](https://user-images.githubusercontent.com/10224565/63363411-6ed6d200-c36b-11e9-8a45-aac40e623144.png)

