### PR TITLE
refactor: compare app label value against app name and UID

### DIFF
--- a/src/components/mobileservices/BindingPanel.js
+++ b/src/components/mobileservices/BindingPanel.js
@@ -20,7 +20,7 @@ export class BindingPanel extends Component {
     this.validate = this.validate.bind(this);
     this.onFormChange = this.onFormChange.bind(this);
     const serviceName = this.props.service.getName();
-    const p = { appName: this.props.appName, appUid: this.props.appUid, service: this.props.service };
+    const p = { appName: this.props.appName, service: this.props.service };
     const bindingFormConfig = this.props.service.getBindingForm(p);
     const { schema, uiSchema, validationRules, onChangeHandler } = bindingFormConfig;
     const { service } = this.props;

--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -64,7 +64,7 @@ class BoundServiceRow extends Component {
     let propertyFragment;
 
     const docUrl = this.props.service.getDocumentationUrl();
-    const serviceConfigurations = this.props.service.getConfiguration(this.props.appUid);
+    const serviceConfigurations = this.props.service.getConfiguration(this.props.appName);
 
     if (docUrl) {
       documentationFragment = (
@@ -128,7 +128,7 @@ class BoundServiceRow extends Component {
       return null;
     }
 
-    if (this.props.service.getCustomResourcesForApp(this.props.appUid).length >= 2) {
+    if (this.props.service.getCustomResourcesForApp(this.props.appName).length >= 2) {
       return null;
     }
 
@@ -136,7 +136,7 @@ class BoundServiceRow extends Component {
   }
 
   renderDeleteBindingDropdowns() {
-    const crs = this.props.service.getCustomResourcesForApp(this.props.appUid);
+    const crs = this.props.service.getCustomResourcesForApp(this.props.appName);
 
     return (
       <DropdownKebab id="delete-binding-id" pullRight>

--- a/src/components/mobileservices/MobileServiceView.js
+++ b/src/components/mobileservices/MobileServiceView.js
@@ -38,7 +38,6 @@ export class MobileServiceView extends Component {
             <BoundServiceRow
               key={service.getId()}
               appName={this.props.appName}
-              appUid={this.props.appUid}
               service={service}
               onCreateBinding={() => this.showBindingPanel(service)}
               onFinished={this.hideBindingPanel}
@@ -106,7 +105,6 @@ export class MobileServiceView extends Component {
           <BindingPanel
             ref={this.bindingPanelRef}
             appName={this.props.appName}
-            appUid={this.props.appUid}
             service={this.state.bindingPanelService}
             showModal
             close={() => this.hideBindingPanel(true)}
@@ -120,7 +118,7 @@ export class MobileServiceView extends Component {
 function mapStateToProps(state, oldProp) {
   const app = MobileApp.find(state.apps.items, oldProp.appName);
   const services = state.services.items.map(item => new MobileService(item));
-  const filteredServices = partition(services, service => service.isBoundToApp(oldProp.appUid));
+  const filteredServices = partition(services, service => service.isBoundToApp(oldProp.appName));
   return { ...state.services, app, boundServices: filteredServices[0], unboundServices: filteredServices[1] };
 }
 

--- a/src/components/mobileservices/MobileServiceView.test.js
+++ b/src/components/mobileservices/MobileServiceView.test.js
@@ -20,7 +20,6 @@ describe('MobileServiceView', () => {
     const wrapper = shallow(
       <MobileServiceView
         appName="appName"
-        appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
         boundServices={props.boundServices}
         unboundServices={props.unboundServices}
         fetchAndWatchServices={() => 'appName'}
@@ -53,7 +52,6 @@ describe('MobileServiceView', () => {
     const wrapper = shallow(
       <MobileServiceView
         appName="appName"
-        appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
         boundServices={props.boundServices}
         unboundServices={props.unboundServices}
         fetchAndWatchServices={() => 'appName'}
@@ -117,7 +115,6 @@ describe('MobileServiceView', () => {
         <BrowserRouter>
           <MobileServiceView
             appName="appName"
-            appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
             boundServices={props.boundServices}
             unboundServices={props.unboundServices}
             fetchAndWatchServices={() => 'appName'}
@@ -177,7 +174,6 @@ describe('MobileServiceView', () => {
         <BrowserRouter>
           <MobileServiceView
             appName="appName"
-            appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
             boundServices={props.boundServices}
             unboundServices={props.unboundServices}
             fetchAndWatchServices={() => 'appName'}
@@ -234,7 +230,6 @@ describe('MobileServiceView', () => {
         <BrowserRouter>
           <MobileServiceView
             appName="appName"
-            appUid="0e35c6cf-0792-4d7a-952d-05618cca6a6e"
             boundServices={props.boundServices}
             unboundServices={props.unboundServices}
             fetchAndWatchServices={() => 'appName'}

--- a/src/containers/Client.js
+++ b/src/containers/Client.js
@@ -136,7 +136,6 @@ export class Client extends Component {
 
   render() {
     const mobileApp = this.getMobileApp();
-    const appUid = mobileApp.getUID();
     const clientInfo = { clientId: mobileApp.getName() };
     const { selectedTab } = this.state;
     const appName = this.props.match.params.id;
@@ -172,7 +171,7 @@ export class Client extends Component {
                   <ConfigurationView app={mobileApp} appName={appName} />
                 </TabPane>
                 <TabPane eventKey={TAB_MOBILE_SERVICES.key}>
-                  <MobileServiceView appName={appName} appUid={appUid} />
+                  <MobileServiceView appName={appName} />
                 </TabPane>
                 {this.props.buildTabEnabled ? (
                   <TabPane eventKey={TAB_BUILDS.key}>

--- a/src/models/mobileservices/customresource.js
+++ b/src/models/mobileservices/customresource.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash-es';
+import { get, find } from 'lodash-es';
 import Resource from '../k8s/resource';
 import Status from '../k8s/status';
 
@@ -26,14 +26,6 @@ export class CustomResource extends Resource {
     return CustomResource.READY_STATUSES.indexOf(phase) > -1;
   }
 
-  hasAppLabel(appUid) {
-    const labels = this.metadata.get('labels');
-    if (labels) {
-      return labels['mobile.aerogear.org/client'] === appUid;
-    }
-    return false;
-  }
-
   isInProgress() {
     const phase = this.status.get('phase');
     return CustomResource.INPROGRESS_STATUSES.indexOf(phase) > -1;
@@ -41,6 +33,10 @@ export class CustomResource extends Resource {
 
   getOwners() {
     return get(this, 'data.metadata.ownerReferences');
+  }
+
+  isOwner(appName) {
+    return !!find(this.getOwners(), o => o.name === appName);
   }
 
   isFailed() {

--- a/src/models/mobileservices/datasync.js
+++ b/src/models/mobileservices/datasync.js
@@ -103,16 +103,13 @@ export class DataSyncCR extends CustomResource {
   }
 
   static newInstance(params) {
-    const { CLIENT_ID, appUid } = params;
+    const { CLIENT_ID } = params;
     const { url, graphqlEndpoint } = params.syncServerConfig;
     return {
       apiVersion: 'v1',
       kind: 'ConfigMap',
       metadata: {
-        name: `${CLIENT_ID}-data-sync-binding`,
-        labels: {
-          'mobile.aerogear.org/client': appUid
-        }
+        name: `${CLIENT_ID}-data-sync-binding`
       },
       data: {
         syncServerUrl: url,

--- a/src/models/mobileservices/keycloakrealmcr.js
+++ b/src/models/mobileservices/keycloakrealmcr.js
@@ -121,17 +121,14 @@ export class KeycloakRealmCR extends CustomResource {
   }
 
   static newInstance(params) {
-    const { CLIENT_ID, appUid } = params;
+    const { CLIENT_ID } = params;
     const { realmId, adminUsername, adminPassword } = params.realmSettings;
     const { clientId, CLIENT_TYPE } = params.clientSettings;
     return {
       apiVersion: 'aerogear.org/v1alpha1',
       kind: 'KeycloakRealm',
       metadata: {
-        name: realmId,
-        labels: {
-          'mobile.aerogear.org/client': appUid
-        }
+        name: realmId
       },
       spec: {
         id: realmId,

--- a/src/models/mobileservices/mobilesecurityserviceappcr.js
+++ b/src/models/mobileservices/mobilesecurityserviceappcr.js
@@ -87,15 +87,12 @@ export class MobileSecurityServiceAppCR extends CustomResource {
     };
   }
 
-  static newInstance({ appName, appUid, appConfig: { appId } }) {
+  static newInstance({ appName, appConfig: { appId } }) {
     return {
       apiVersion: 'mobile-security-service.aerogear.org/v1alpha1',
       kind: 'MobileSecurityServiceApp',
       metadata: {
-        name: `${appName}-security`,
-        labels: {
-          'mobile.aerogear.org/client': appUid
-        }
+        name: `${appName}-security`
       },
       spec: {
         appName,

--- a/src/models/mobileservices/mobileservice.js
+++ b/src/models/mobileservices/mobileservice.js
@@ -44,12 +44,12 @@ export class MobileService {
     return this.customResources.length > 0 && find(this.customResources, cr => cr.isReady());
   }
 
-  isBoundToApp(uid) {
-    return this.customResources.length > 0 && find(this.customResources, cr => cr.isReady() && cr.hasAppLabel(uid));
+  isBoundToApp(appName) {
+    return this.customResources.length > 0 && find(this.customResources, cr => cr.isReady() && cr.isOwner(appName));
   }
 
-  getCustomResourcesForApp(uid) {
-    return filter(this.customResources, cr => cr.hasAppLabel(uid));
+  getCustomResourcesForApp(appName) {
+    return filter(this.customResources, cr => cr.isOwner(appName));
   }
 
   getServiceInstanceName() {
@@ -64,11 +64,8 @@ export class MobileService {
     return this.customResourceClass.bindForm(params);
   }
 
-  isBindingOperationInProgress(owner) {
-    const inprogressCR = find(
-      this.customResources,
-      cr => (owner ? find(cr.getOwners(), o => o.name === owner) : true) && cr.isInProgress()
-    );
+  isBindingOperationInProgress(appName) {
+    const inprogressCR = find(this.customResources, cr => (!appName || cr.isOwner(appName)) && cr.isInProgress());
     return inprogressCR != null;
   }
 
@@ -93,12 +90,12 @@ export class MobileService {
     return this.data.bindCustomResource;
   }
 
-  newCustomResource(formdata, ownerMetadata) {
-    return this.customResourceClass.newInstance({ appUid: ownerMetadata.uid, ...formdata });
+  newCustomResource(formdata) {
+    return this.customResourceClass.newInstance({ ...formdata });
   }
 
-  getConfiguration(appUid) {
-    const crs = this.getCustomResourcesForApp(appUid);
+  getConfiguration(appName) {
+    const crs = this.getCustomResourcesForApp(appName);
     const configurations = reduce(crs, (all, cr) => all.concat(cr.getConfiguration(this.data.host)), []);
     const uniqConfigs = uniqBy(configurations, config => config.label);
     return uniqConfigs;

--- a/src/models/mobileservices/pushvariantcr.js
+++ b/src/models/mobileservices/pushvariantcr.js
@@ -1,12 +1,11 @@
 import { find } from 'lodash-es';
 import { CustomResource } from './customresource';
 
-function hasPlatform(service, appUid, platform) {
-  console.log('appName', appUid);
+function hasPlatform(service, appName, platform) {
   return (
     service.customResources &&
     find(
-      service.getCustomResourcesForApp(appUid),
+      service.getCustomResourcesForApp(appName),
       cr => typeof cr.getPlatform === 'function' && cr.getPlatform() === platform
     )
   );
@@ -46,8 +45,8 @@ export class PushVariantCR extends CustomResource {
 
   static bindForm(params) {
     const { service } = params;
-    const hasIOS = hasPlatform(service, params.appUid, 'IOSVariant');
-    const hasAndroid = hasPlatform(service, params.appUid, 'AndroidVariant');
+    const hasIOS = hasPlatform(service, params.appName, 'IOSVariant');
+    const hasAndroid = hasPlatform(service, params.appName, 'AndroidVariant');
     let defaultPlatform = 'Android';
     let platforms = ['Android', 'iOS'];
     const androidConfig = {
@@ -236,7 +235,7 @@ export class PushVariantCR extends CustomResource {
   }
 
   static newInstance(params) {
-    const { CLIENT_ID, CLIENT_TYPE, appUid } = params;
+    const { CLIENT_ID, CLIENT_TYPE } = params;
 
     switch (CLIENT_TYPE) {
       case 'Android':
@@ -244,10 +243,7 @@ export class PushVariantCR extends CustomResource {
           apiVersion: 'push.aerogear.org/v1alpha1',
           kind: 'AndroidVariant',
           metadata: {
-            name: `${CLIENT_ID}-android-ups-variant`,
-            labels: {
-              'mobile.aerogear.org/client': appUid
-            }
+            name: `${CLIENT_ID}-android-ups-variant`
           },
           spec: {
             description: 'UPS Android Variant',
@@ -261,10 +257,7 @@ export class PushVariantCR extends CustomResource {
           apiVersion: 'push.aerogear.org/v1alpha1',
           kind: 'IOSVariant',
           metadata: {
-            name: `${CLIENT_ID}-ios-ups-variant`,
-            labels: {
-              'mobile.aerogear.org/client': CLIENT_ID
-            }
+            name: `${CLIENT_ID}-ios-ups-variant`
           },
           spec: {
             description: 'UPS iOS Variant',


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-9779

Follow up to https://github.com/aerogear/mobile-developer-console/pull/386.

This change will make the change introduced in https://github.com/aerogear/mobile-developer-console/pull/386 backwards compatible, by checking the app label for the new value type (app UID) as well as the old value type (app name).

## Verification

1. Create a new app.
2. Bind all services.
3. The services should show in the correct lists (Bound Services or Unbound Services).
4. Inspect the service CRs. They should no longer have any labels.