### PR TITLE
Replace pf alerts

### DIFF
--- a/src/containers/ErrorMessages.js
+++ b/src/containers/ErrorMessages.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
 import { dismiss, dismissAll } from '../actions/errors'
-import './../index.css';
+import './style/index.css';
 
 export class ErrorMessages extends Component {
   constructor(props) {

--- a/src/containers/ErrorMessages.js
+++ b/src/containers/ErrorMessages.js
@@ -2,16 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
-import { dismiss, dismissAll } from '../actions/errors'
-import './style/index.css';
+import { dismiss, dismissAll } from '../actions/errors';
 
 export class ErrorMessages extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {alertOneVisible: true};
-    this.hideAlertOne = () => this.setState({ alertOneVisible: false });
-
-  }
   componentWillMount() {
     const { history, dismissAllErrors } = this.props;
     this.unlisten = history.listen(dismissAllErrors);
@@ -23,17 +16,12 @@ export class ErrorMessages extends Component {
 
   render() {
     const { errors, dismissError } = this.props;
-    const { alertOneVisible } = this.state;
     return (
       <div className="mdc-alert-group">
         {[...new Set(errors.map(error => error.message))].map((error, index) => (
-          <React.Fragment>
-            {alertOneVisible && (
-              <Alert key={index} variant="danger" title="Danger alert title" action={<AlertActionCloseButton onClose={this.hideAlertOne} />}>
-                {error}
-              </Alert>
-            )}
-          </React.Fragment>
+          <Alert key={index} variant="danger" title="Request Failed" action={<AlertActionCloseButton onClose={() => dismissError(error)} />}>
+            {error}
+          </Alert>
         ))}
       </div>
     );

--- a/src/containers/ErrorMessages.js
+++ b/src/containers/ErrorMessages.js
@@ -1,10 +1,17 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { ToastNotificationList, ToastNotification } from 'patternfly-react';
+import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
-import { dismiss, dismissAll } from '../actions/errors';
+import { dismiss, dismissAll } from '../actions/errors'
+import './../index.css';
 
 export class ErrorMessages extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {alertOneVisible: true};
+    this.hideAlertOne = () => this.setState({ alertOneVisible: false });
+
+  }
   componentWillMount() {
     const { history, dismissAllErrors } = this.props;
     this.unlisten = history.listen(dismissAllErrors);
@@ -16,14 +23,19 @@ export class ErrorMessages extends Component {
 
   render() {
     const { errors, dismissError } = this.props;
+    const { alertOneVisible } = this.state;
     return (
-      <ToastNotificationList>
+      <div className="mdc-alert-group">
         {[...new Set(errors.map(error => error.message))].map((error, index) => (
-          <ToastNotification key={index} onDismiss={() => dismissError(error)}>
-            <span>{error}</span>
-          </ToastNotification>
+          <React.Fragment>
+            {alertOneVisible && (
+              <Alert key={index} variant="danger" title="Danger alert title" action={<AlertActionCloseButton onClose={this.hideAlertOne} />}>
+                {error}
+              </Alert>
+            )}
+          </React.Fragment>
         ))}
-      </ToastNotificationList>
+      </div>
     );
   }
 }

--- a/src/containers/ErrorMessages.js
+++ b/src/containers/ErrorMessages.js
@@ -19,7 +19,7 @@ export class ErrorMessages extends Component {
     return (
       <div className="mdc-alert-group">
         {[...new Set(errors.map(error => error.message))].map((error, index) => (
-          <Alert 
+          <Alert
             key={index}
             variant="danger"
             title="Request Failed"

--- a/src/containers/ErrorMessages.js
+++ b/src/containers/ErrorMessages.js
@@ -19,7 +19,12 @@ export class ErrorMessages extends Component {
     return (
       <div className="mdc-alert-group">
         {[...new Set(errors.map(error => error.message))].map((error, index) => (
-          <Alert key={index} variant="danger" title="Request Failed" action={<AlertActionCloseButton onClose={() => dismissError(error)} />}>
+          <Alert 
+            key={index}
+            variant="danger"
+            title="Request Failed"
+            action={<AlertActionCloseButton onClose={() => dismissError(error)} />}
+          >
             {error}
           </Alert>
         ))}

--- a/src/containers/ErrorMessages.test.js
+++ b/src/containers/ErrorMessages.test.js
@@ -13,13 +13,13 @@ describe('ErrorMessages', () => {
     expect(wrapper.find('.alert.toast-pf')).toHaveLength(2);
     expect(
       wrapper
-        .find('div.toast-notifications-list-pf')
+        .find('div.mdc-alert-group')
         .childAt(0)
         .text()
     ).toEqual('error1');
     expect(
       wrapper
-        .find('div.toast-notifications-list-pf')
+        .find('div.mdc-alert-group')
         .childAt(1)
         .text()
     ).toEqual('error2');

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1,5 +1,14 @@
 @charset "UTF-8";
 /* PatternFly */
+@import url("~@patternfly/react-core/dist/styles/base.css");
+@import url("~@patternfly/patternfly/patternfly-variables.css");
+@import url("~@patternfly/patternfly/patternfly-common.css");
+@import url("~@patternfly/patternfly/patternfly-globals.css");
+@import url("~@patternfly/patternfly/utilities/Spacing/spacing.css");
+@import url("~@patternfly/patternfly/utilities/BoxShadow/box-shadow.css");
+@import url("~@patternfly/patternfly/layouts/Level/level.css");
+@import url("~@patternfly/patternfly/layouts/Split/split.css");
+@import url("~@patternfly/patternfly/utilities/Display/display.css");
 @font-face {
   font-family: "Open Sans";
   font-style: normal;
@@ -16861,3 +16870,20 @@ table.dataTable {
 .wizard-pf-step-alt-substep.disabled > a:hover,
 .wizard-pf-sidebar .list-group-item.disabled > a:hover {
   cursor: not-allowed; }
+
+/* pf4 base styles */
+/* Overrides until the Alert Group is available in pf4 */
+.mdc-alert-group {
+  position: fixed;
+  top: var(--pf-global--spacer--2xl);
+  right: var(--pf-global--spacer--xl);
+  z-index: var(--pf-global--ZIndex--2xl);
+  width: calc(100% - calc(var(--pf-global--spacer--xl) * 2));
+  max-width: 600px; }
+
+.mdc-alert-group .pf-c-alert:not(:last-child) {
+  margin-bottom: var(--pf-global--spacer--sm); }
+
+.mdc-alert-group .pf-c-alert .pf-c-alert__title {
+  line-height: var(--pf-global--LineHeight--md);
+  font-weight: 500; }

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -1,2 +1,33 @@
 @import "./variables";
 @import "patternfly";
+
+/* pf4 base styles */
+@import url('~@patternfly/react-core/dist/styles/base.css');
+@import url('~@patternfly/patternfly/patternfly-variables.css');
+@import url('~@patternfly/patternfly/patternfly-common.css');
+@import url('~@patternfly/patternfly/patternfly-globals.css');
+@import url('~@patternfly/patternfly/utilities/Spacing/spacing.css');
+@import url('~@patternfly/patternfly/utilities/BoxShadow/box-shadow.css');
+@import url('~@patternfly/patternfly/layouts/Level/level.css');
+@import url('~@patternfly/patternfly/layouts/Split/split.css');
+@import url('~@patternfly/patternfly/utilities/Display/display.css');
+
+
+/* Overrides until the Alert Group is available in pf4 */
+.mdc-alert-group {
+  position: fixed;
+  top: var(--pf-global--spacer--2xl);
+  right: var(--pf-global--spacer--xl);
+  z-index: var(--pf-global--ZIndex--2xl);
+  width: calc(100% - calc(var(--pf-global--spacer--xl) * 2));
+  max-width: 600px;
+}
+
+.mdc-alert-group .pf-c-alert:not(:last-child) {
+  margin-bottom: var(--pf-global--spacer--sm);
+}
+
+.mdc-alert-group .pf-c-alert .pf-c-alert__title {
+  line-height: var(--pf-global--LineHeight--md);
+  font-weight: 500;
+}


### PR DESCRIPTION
## Motivation
Replace Alerts with pf4 components

## What
To replace alerts.

## Why
To align with the pf4 migration efforts.

## How
Replace the Toast notification components with alerts.

## Verification Steps
Create an error by clicking on the "Create a binding" button 

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1087" alt="Screen Shot 2019-08-30 at 10 03 41 AM" src="https://user-images.githubusercontent.com/20118816/64026888-a123c480-cb0d-11e9-99c8-b3adb56ac72f.png">

 

