### PR TITLE
Restart the server on kubectl init errors

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -119,6 +119,9 @@ async function initKubeClient() {
     return kubeclient;
   } catch (e) {
     console.error('Failed to init kube client', e);
+
+    // Exiting the server. Waiting 5 seconds to avoid strict loops
+    setTimeout(() => process.exit(1), 5000);
     return null;
   }
 }


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/INTLY-3335

## What
Added a process.exit to the server on kubectl client initialization errors.

## Why
It happens sometimes after a fresh installation that CRDs are not ready yet when MDC starts, making the server fail the kubectl client initializations: restarting the pod fixes the issue.

Since pods are automatically restarted, exiting will solve the issue.



