### PR TITLE
Documentation menu item update

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -7,3 +7,6 @@ html, body, #root, .App {
 
 .App > .navbar {
   flex: 0 0 60px; }
+
+.getting-started {
+  color: #151515; }

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -9,4 +9,5 @@ html, body, #root, .App {
   flex: 0 0 60px; }
 
 .getting-started {
-  color: #151515; }
+  color: #151515;
+  font-weight: 400; }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -23,7 +23,7 @@ import Configuration from '../containers/Configuration';
 import Client from '../containers/Client';
 import ErrorMessages from '../containers/ErrorMessages';
 import { fetchUserInfo } from '../actions/users';
-import { getFavIcon, getLogo, getDocumentation } from '../services/openshift';
+import { getFavIcon, getLogo } from '../services/openshift';
 import './App.css';
 
 class App extends React.Component {
@@ -85,7 +85,14 @@ class App extends React.Component {
 
     const questionIconItems = [
       <DropdownItem key="mdc_docs">
-        <a href='https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html/getting_started_with_mobile_developer_services/index' target='_blank' className='getting-started'>Getting Started</a>
+        <a
+          href="https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html/getting_started_with_mobile_developer_services/index"
+          target="_blank"
+          className="getting-started"
+          rel="noopener noreferrer"
+        >
+          Getting Started
+        </a>
       </DropdownItem>,
       <DropdownItem key="about" onClick={this.onModalToggle} component="button">
         About

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -85,7 +85,7 @@ class App extends React.Component {
 
     const questionIconItems = [
       <DropdownItem key="mdc_docs">
-        <a href={getDocumentation()}>Documentation</a>
+        <a href='https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html/getting_started_with_mobile_developer_services/index' target='_blank' className='getting-started'>Getting Started</a>
       </DropdownItem>,
       <DropdownItem key="about" onClick={this.onModalToggle}>
         About

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -87,7 +87,7 @@ class App extends React.Component {
       <DropdownItem key="mdc_docs">
         <a href='https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html/getting_started_with_mobile_developer_services/index' target='_blank' className='getting-started'>Getting Started</a>
       </DropdownItem>,
-      <DropdownItem key="about" onClick={this.onModalToggle}>
+      <DropdownItem key="about" onClick={this.onModalToggle} component="button">
         About
       </DropdownItem>
     ];

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -90,11 +90,19 @@ class App extends React.Component {
           target="_blank"
           className="getting-started"
           rel="noopener noreferrer"
+          aria-label="getting started"
         >
           Getting Started
         </a>
       </DropdownItem>,
-      <DropdownItem key="about" onClick={this.onModalToggle} component="button">
+      <DropdownItem
+        key="about"
+        onClick={this.onModalToggle}
+        component="button"
+        role="button"
+        aria-label="about"
+        aria-expanded={this.state.isModalOpen}
+      >
         About
       </DropdownItem>
     ];

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -13,4 +13,5 @@ html, body, #root, .App {
 
 .getting-started {
   color: #151515;
+  font-weight: 400;
 }

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -10,3 +10,7 @@ html, body, #root, .App {
 .App > .navbar {
   flex: 0 0 60px;
 }
+
+.getting-started {
+  color: #151515;
+}

--- a/src/components/mobileservices/BoundServiceRow.test.js
+++ b/src/components/mobileservices/BoundServiceRow.test.js
@@ -280,7 +280,6 @@ describe('BoundServiceRow - UPS - 3 bindings', () => {
     expect(wrapper.find('BindButton')).toHaveLength(0);
     // normally we show the binding status in the UnboundServiceRow, not in the bound one.
     // but, as there might be a binding in progress, we still need to show this status in BoundServiceRow too
-    expect(wrapper.find('BindingStatus')).toHaveLength(1);
     expect(bindingSchema.properties.CLIENT_TYPE.default).toEqual('Foo');
     expect(bindingSchema.properties.CLIENT_TYPE.enum).toEqual(['Foo', 'Bar', 'Moo']);
   });


### PR DESCRIPTION
Update the Help icon > Documentation menu item.

- Change link from Documentation to "Getting started"
- Update the link URL to this: https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html/getting_started_with_mobile_developer_services/index
- Link should open in a new tab/window