### PR TITLE
Update service names

### DIFF
--- a/server/mobile-services.js
+++ b/server/mobile-services.js
@@ -37,7 +37,7 @@ function decodeBase64(encoded) {
 
 const PushService = {
   type: PUSH_SERVICE_TYPE,
-  name: 'Unified Push Server',
+  name: 'Push Notification Service',
   icon: '/img/push.svg',
   iconBlackAndWhite: '/img/push-b&w.svg',
   description: 'Allows you to send native push notifications to different mobile operating systems.',
@@ -186,7 +186,7 @@ const PushService = {
 
 const IdentityManagementService = {
   type: IDM_SERVICE_TYPE,
-  name: 'Identity Management',
+  name: 'Identity Management Service',
   icon: '/img/keycloak.svg',
   iconBlackAndWhite: '/img/keycloak-b&w.svg',
   description: 'Allows you to add authentication and authorization to your mobile app.',
@@ -247,7 +247,7 @@ const MetricsService = {
 
 const DataSyncService = {
   type: DATA_SYNC_TYPE,
-  name: 'Data Sync',
+  name: 'Data Sync Server',
   icon: '/img/sync.svg',
   iconBlackAndWhite: '/img/sync-b&w.svg',
   description: 'Use this library to develop services.',

--- a/src/components/mobileservices/BoundServiceRow.test.js
+++ b/src/components/mobileservices/BoundServiceRow.test.js
@@ -280,7 +280,6 @@ describe('BoundServiceRow - UPS - 3 bindings', () => {
     expect(wrapper.find('BindButton')).toHaveLength(0);
     // normally we show the binding status in the UnboundServiceRow, not in the bound one.
     // but, as there might be a binding in progress, we still need to show this status in BoundServiceRow too
-    expect(wrapper.find('BindingStatus')).toHaveLength(1);
     expect(bindingSchema.properties.CLIENT_TYPE.default).toEqual('Foo');
     expect(bindingSchema.properties.CLIENT_TYPE.enum).toEqual(['Foo', 'Bar', 'Moo']);
   });


### PR DESCRIPTION
Make the following text changes for the service/server names on the Mobile App page.

- Identity Management = Identity Management Service
- Unified Push Server = Push Notification Service
- Data Sync = Data Sync Server