### PR TITLE
Fix overflow menu

### DIFF
--- a/src/components/mobileservices/BoundServiceRow.js
+++ b/src/components/mobileservices/BoundServiceRow.js
@@ -6,8 +6,18 @@ import {
   DataListAction,
   DataListToggle,
   DataListContent,
-  DataListItemCells
+  DataListItemCells,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  KebabToggle
 } from '@patternfly/react-core';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuItem
+} from '@patternfly/react-core/dist/esm/experimental';
 import { get as _get } from 'lodash-es';
 import './ServiceRow.css';
 import DeleteItemButton from '../../containers/DeleteItemButton';
@@ -33,6 +43,12 @@ class BoundServiceRow extends Component {
     this.state = {
       expanded: [],
       isOpen1: false
+    };
+
+    this.onToggle = isOpen => {
+      this.setState({
+        isOpen
+      });
     };
 
     this.onToggle1 = isOpen1 => {
@@ -149,7 +165,7 @@ class BoundServiceRow extends Component {
     );
   }
 
-  renderDeleteBindingButtons() {
+  renderDeleteBindingButtons(parent) {
     const crs = this.props.service.getCustomResourcesForApp(this.props.appName);
     return (
       <React.Fragment>
@@ -160,6 +176,7 @@ class BoundServiceRow extends Component {
             itemType="config"
             itemName={cr.getName()}
             onDelete={() => this.props.onDeleteBinding(cr)}
+            parent={parent}
           />
         ))}
       </React.Fragment>
@@ -174,6 +191,14 @@ class BoundServiceRow extends Component {
         index >= 0 ? [...expanded.slice(0, index), ...expanded.slice(index + 1, expanded.length)] : [...expanded, id];
       this.setState(() => ({ expanded: newExpanded }));
     };
+    const isPushVariant = this.props.service.isUPSService();
+    const { isOpen } = this.state;
+    const dropdownItems = [
+      <DropdownItem key="action" onClick={this.props.onCreateBinding}>
+        {this.renderDeleteBindingButtons() ? 'Create a binding' : undefined}
+      </DropdownItem>,
+      this.renderDeleteBindingButtons('isDropdown')
+    ];
     return (
       <DataListItem
         key={this.props.service.getId()}
@@ -189,8 +214,29 @@ class BoundServiceRow extends Component {
           />
           {this.renderServiceBadge()}
           <DataListAction aria-labelledby="ex-item1 ex-action1" id="ex-action1">
-            {this.renderBindingButtons()}
-            {this.renderDeleteBindingButtons()}
+            {isPushVariant ? (
+              <OverflowMenu breakpoint="xl">
+              <OverflowMenuContent>
+                <OverflowMenuItem>
+                  {this.renderBindingButtons()}
+                </OverflowMenuItem>
+                {this.renderDeleteBindingButtons('isOverflowMenu')}
+              </OverflowMenuContent>
+              <OverflowMenuControl>
+                <Dropdown
+                  onSelect={this.onSelect}
+                  position={DropdownPosition.right}
+                  toggle={<KebabToggle onToggle={this.onToggle} />}
+                  isOpen={isOpen}
+                  isPlain
+                  dropdownItems={dropdownItems}
+                />
+              </OverflowMenuControl>
+            </OverflowMenu>
+            ) : (
+            this.renderBindingButtons(),
+            this.renderDeleteBindingButtons()
+            )}
           </DataListAction>
         </DataListItemRow>
         <DataListContent

--- a/src/containers/DeleteItemButton.js
+++ b/src/containers/DeleteItemButton.js
@@ -1,9 +1,6 @@
 import React, { Component } from 'react';
-import { Dropdown, DropdownItem, DropdownPosition, KebabToggle, Modal, Button } from '@patternfly/react-core';
+import { Modal, Button, DropdownItem } from '@patternfly/react-core';
 import {
-  OverflowMenu,
-  OverflowMenuControl,
-  OverflowMenuContent,
   OverflowMenuItem
 } from '@patternfly/react-core/dist/esm/experimental';
 import { connect } from 'react-redux';
@@ -79,40 +76,27 @@ class DeleteItemButton extends Component {
   }
 
   render() {
-    const { itemType, title = 'Delete' } = this.props;
+    const { itemType, title = 'Delete', parent } = this.props;
     const itemName = this.getItemName();
     const { showModal } = this.state;
-    const { isOpen } = this.state;
-    const dropdownItems = [
-      <DropdownItem key="action" onClick={this.openDialog}>
-        {title}
-      </DropdownItem>
-    ];
     return (
       <Route
         render={props => (
           <React.Fragment>
-            {title.includes('Android') || title.includes('IOS') ? (
-              <OverflowMenu breakpoint="xl">
-                <OverflowMenuContent>
+            { parent === 'isDropdown' ? (
+              <DropdownItem onClick={this.openDialog}>
+                {title}
+              </DropdownItem>
+              ) : (
+                parent === 'isOverflowMenu' ? (
                   <OverflowMenuItem>
                     <Button onClick={this.openDialog}>{title}</Button>
                   </OverflowMenuItem>
-                </OverflowMenuContent>
-                <OverflowMenuControl>
-                  <Dropdown
-                    onSelect={this.onSelect}
-                    position={DropdownPosition.right}
-                    toggle={<KebabToggle onToggle={this.onToggle} />}
-                    isOpen={isOpen}
-                    isPlain
-                    dropdownItems={dropdownItems}
-                  />
-                </OverflowMenuControl>
-              </OverflowMenu>
-            ) : (
-              <Button onClick={this.openDialog}>{title}</Button>
-            )}
+                ) : (
+                  <Button onClick={this.openDialog}>{title}</Button>
+                )
+              )
+            }
             <Modal
               isSmall
               title="Confirm Delete"

--- a/src/reducers/services.js
+++ b/src/reducers/services.js
@@ -18,7 +18,7 @@ const defaultState = {
   isReading: false
 };
 
-function addOrReplaceItem(array, item, predicate) {
+function addOrReplaceItem(array = [], item, predicate) {
   const index = array.findIndex(predicate);
   if (index >= 0) {
     return [...array.slice(0, index), item, ...array.slice(index + 1)];


### PR DESCRIPTION
For the push service, now all the variants are combined in the one overflowMenu component

<img width="1192" alt="Screen Shot 2019-11-04 at 4 34 13 PM" src="https://user-images.githubusercontent.com/20118816/68160249-54030b00-ff21-11e9-8d11-e72934f1cf62.png">

@tiffanynolan this list is quite large here
<img width="776" alt="Screen Shot 2019-11-04 at 4 34 20 PM" src="https://user-images.githubusercontent.com/20118816/68160256-57969200-ff21-11e9-9d7e-a65d0c8cf4de.png">

<img width="590" alt="Screen Shot 2019-11-04 at 4 34 26 PM" src="https://user-images.githubusercontent.com/20118816/68160257-5a918280-ff21-11e9-9c7f-00a2252569dd.png">

